### PR TITLE
Fix partner-less people not showing in Combined mode

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1137,16 +1137,16 @@ class Dot {
 						}
 
 						// Add father & mother
-                    $h = $f->husband();
-                    $w = $f->wife();
-                    if($h)
-                        $husb_id = $h->xref();
-                    else
-                        $husb_id = null;
-                    if($w)
-                        $wife_id = $w->xref();
-                    else
-                        $wife_id = null;
+						$h = $f->husband();
+						$w = $f->wife();
+						if($h)
+							$husb_id = $h->xref();
+						else
+							$husb_id = null;
+						if($w)
+							$wife_id = $w->xref();
+						else
+							$wife_id = null;
 
 						if (!empty($husb_id)) {
 							$this->families[$fid]["has_children"] = TRUE;

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -944,7 +944,7 @@ class Dot {
 		// Add the family nr which he/she belongs to as spouse (needed when "combined" mode is used)
 		if ($this->settings["diagram_type"] == "combined") {
 			$fams = $i->spouseFamilies();
-			if (!empty($fams)) {
+			if (count($fams) > 0) {
 
 				// --- DEBUG ---
 				if ($this->settings["debug"]) {
@@ -1063,7 +1063,7 @@ class Dot {
 				}
 				// -------------
 
-				if (!empty($famc)) {
+				if (count($famc) > 0) {
 					// For every family where the INDI is listed as CHILD
 					foreach ($famc as $fam) {
 						// Get the family ID


### PR DESCRIPTION
The Collection output by `$i->spouseFamilies` was not checked correctly for emptiness, causing all people without a partner to be missing from the Combined diagram type.

The second place I fixed the check has something to do with rendering of families, although I am not quite sure exactly what it changes.