### PR TITLE
Fix "Mark not blood-related" option

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1355,11 +1355,11 @@ class Dot {
 						}
 						// -------------
 
-						//if ($this->settings["mark_not_related"] == TRUE) {
+						if ($this->settings["mark_not_related"] == TRUE) {
 							$this->addIndiToList($spouse_id, FALSE, FALSE, FALSE, FALSE, FALSE, $ind, $ance_level, $desc_level);
-						//} else {
-						//	$this->addIndiToList($spouse_id, FALSE, FALSE, FALSE, FALSE, TRUE, $ind, $ance_level, $desc_level);
-						//}
+						} else {
+							$this->addIndiToList($spouse_id, FALSE, FALSE, FALSE, FALSE, TRUE, $ind, $ance_level, $desc_level);
+						}
 					}
 
 				}


### PR DESCRIPTION
The option "Mark not blood-related people with different color" is present in the UI, but currently does nothing. 

This PR simply re-adds the lines that were removed. This allows non-blood related people to obtain a color just like the blood-related people instead of just a dull grey background