### PR TITLE
Fix remember download option

### DIFF
--- a/config.php
+++ b/config.php
@@ -121,6 +121,7 @@ $GVE_CONFIG["custom"]["death_text"] = "+";	// Text shown on chart before the dea
 
 // Settings
 $GVE_CONFIG["settings"]["use_abbr_place"] = FALSE;
+$GVE_CONFIG["settings"]["download"] = TRUE;
 
 // Deafult max levels of ancestors
 $GVE_CONFIG["settings"]["ance_level"] = 5;

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -103,6 +103,7 @@ class Dot {
 		$this->settings["no_fams"] = FALSE;
 
 		$this->settings["use_abbr_place"] = $GVE_CONFIG["settings"]["use_abbr_place"];
+		$this->settings["download"] = $GVE_CONFIG["settings"]["download"];
 		$this->settings["debug"] = $GVE_CONFIG["debug"];
 
 		$this->settings["ance_level"] = $GVE_CONFIG["settings"]["ance_level"];

--- a/module.php
+++ b/module.php
@@ -122,7 +122,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 
 		$individual = $this->getIndividual($tree, $request->getQueryParams()['xref']);
 
-		$userDefaultVars = [ //Defaults (this cloud be defined in the config?)
+		$userDefaultVars = [ //Defaults (this could be defined in the config?)
 			"otype" => "svg",
 			"grdir" => $GVE_CONFIG["default_direction"],
 			"mclimit" => $GVE_CONFIG["default_mclimit"],
@@ -157,9 +157,10 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 			"dpi" => $GVE_CONFIG["settings"]["dpi"],
 			"ranksep" => $GVE_CONFIG["settings"]["ranksep"],
 			"nodesep" => $GVE_CONFIG["settings"]["nodesep"],
-			"other_pids" => '',
-			"stop_pid" => '',
-			"other_stop_pids" => ''
+			"other_pids" => "",
+			"stop_pid" => "",
+			"other_stop_pids" => "",
+            "download" => TRUE
 		];
 		if (!isset($_REQUEST['reset']) and isset($_COOKIE["GVEUserDefaults"]) and $_COOKIE["GVEUserDefaults"] != "") {
 			foreach (explode("|", $_COOKIE["GVEUserDefaults"]) as $s) {
@@ -182,7 +183,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 		return $this->viewResponse($this->name() . '::page', [
 			'tree' => $tree,
 			'individual' => $individual,
-			'disposition' => true,
+			'disposition' => false,
 			'title' => 'GVExport',
 			'vars' => $userDefaultVars,
 			'otypes' => $otypes,

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -395,9 +395,10 @@ use Fisharebest\Webtrees\I18N;
         </div>
 
         <div class="row form-group">
-            <label class="col-sm-4 col-form-label wt-page-options-label" for="disposition">Generate a file for download</label>
+            <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[download]">Generate a file for download</label>
             <div class="col-sm-8 wt-page-options-value">
-                <input type="checkbox" name="disposition" id="disposition" value="1" <?= $disposition ? 'checked' : '' ?>>
+                <input type="hidden" name="vars[download]" value="no">
+                <input type="checkbox" name="vars[download]" id="vars[download]" value="1" <?= $vars["download"] == 1 ? 'checked' : ''  ?>>
             </div>
         </div>
 


### PR DESCRIPTION
Previously the "Generate a file for download" setting was not remembered between page loads. This commit should fix this.