### PR TITLE
Fix SVG photos

### DIFF
--- a/config.php
+++ b/config.php
@@ -63,7 +63,7 @@ if ( !empty( $GVE_CONFIG["graphviz_bin"])) {
 
 	$GVE_CONFIG["output"]["svg"]["label"] = "SVG"; #ESL!!! 20090213
 	$GVE_CONFIG["output"]["svg"]["extension"] = "svg";
-	$GVE_CONFIG["output"]["svg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tsvg -o" . $GVE_CONFIG["filename"] . ".svg " . $GVE_CONFIG["filename"] . ".dot";
+	$GVE_CONFIG["output"]["svg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tsvg:cairo -o" . $GVE_CONFIG["filename"] . ".svg " . $GVE_CONFIG["filename"] . ".dot";
 	$GVE_CONFIG["output"]["svg"]["cont_type"] = "image/svg+xml";
 	$GVE_CONFIG["output"]["svg"]["rewrite_media_paths"] = true;
 


### PR DESCRIPTION
Photos in SVG now supported. Requires Cairo for GraphViz, may be supported by default. SVG with images have images embedded, open fine in browser but image viewers seem to have trouble with all by the smallest files (max of about 10 people with photos). Limit seems to be a file size of about 10MB.