### PR TITLE
Fix duplicate PID

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -674,6 +674,8 @@ class Dot {
         }
 
 		if ($this->settings["show_pid"]) {
+			// If PID already in name (from another module), remove it
+			$name = str_replace(" (" . $pid . ")", "", $name);
 			// Show INDI id
 			$name = $name . " (" . $pid . ")";
 		}


### PR DESCRIPTION
Where another module has already added the PID to the name, remove it before we add our one to prevent duplicates.

Fixes #31 