### PR TITLE
Add support for gender X

### DIFF
--- a/config.php
+++ b/config.php
@@ -79,13 +79,15 @@ if ( !empty( $GVE_CONFIG["graphviz_bin"])) {
 }
 
 // Default colors - please use #RRGGBB format
-$GVE_CONFIG["dot"]["colorm"] = "#ADD8E6";	// Default color of male individuals (lightblue)
-$GVE_CONFIG["dot"]["colorf"] = "#FFB6C1";	// Default color of female individuals (lightpink)
-$GVE_CONFIG["dot"]["coloru"] = "#D3D3D3";	// Default color of unknown gender individuals (lightgray)
+$GVE_CONFIG["dot"]["colorm"] = "#ADD8E6";	// Default color of male individuals (light blue)
+$GVE_CONFIG["dot"]["colorf"] = "#FFB6C1";	// Default color of female individuals (light pink)
+$GVE_CONFIG["dot"]["colorx"] = "#FCEAA1";	// Default color of Other gender individuals (light yellow)
+$GVE_CONFIG["dot"]["coloru"] = "#CCEECC";	// Default color of unknown gender individuals (light green)
 $GVE_CONFIG["dot"]["colorm_nr"] = "#F0F8F8";	// Default color of not blood-related male individuals
 $GVE_CONFIG["dot"]["colorf_nr"] = "#F8F2F2";	// Default color of not blood-related female individuals
-$GVE_CONFIG["dot"]["coloru_nr"] = "#F0F0F0";	// Default color of not blood-related unknown gender individuals
-$GVE_CONFIG["dot"]["colorfam"] = "#FFFFE0";	// Default color of families (lightyellow)
+$GVE_CONFIG["dot"]["colorx_nr"] = "#FCF7E3";	// Default color of not blood-related Other gender individuals
+$GVE_CONFIG["dot"]["coloru_nr"] = "#D6EED6";	// Default color of not blood-related unknown gender individuals
+$GVE_CONFIG["dot"]["colorfam"] = "#FFFFE0";	// Default color of families (different light yellow)
 $GVE_CONFIG["dot"]["colorch"] = "#FF0000"; // Default color of changed (waiting for validation) records
 $GVE_CONFIG["dot"]["fontsize"] = "10";	// Default font size
 

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -72,9 +72,11 @@ class Dot {
 		// Load colors
 		$this->colors["colorm"] = $GVE_CONFIG["dot"]["colorm"];
 		$this->colors["colorf"] = $GVE_CONFIG["dot"]["colorf"];
+		$this->colors["colorx"] = $GVE_CONFIG["dot"]["colorx"];
 		$this->colors["coloru"] = $GVE_CONFIG["dot"]["coloru"];
 		$this->colors["colorm_nr"] = $GVE_CONFIG["dot"]["colorm_nr"];
 		$this->colors["colorf_nr"] = $GVE_CONFIG["dot"]["colorf_nr"];
+		$this->colors["colorx_nr"] = $GVE_CONFIG["dot"]["colorx_nr"];
 		$this->colors["coloru_nr"] = $GVE_CONFIG["dot"]["coloru_nr"];
 		$this->colors["colorfam"] = $GVE_CONFIG["dot"]["colorfam"];
 
@@ -413,6 +415,12 @@ class Dot {
 				$fillcolor = $this->colors["colorm"];
 			} else  {
 				$fillcolor = $this->colors["colorm_nr"];
+			}
+		} elseif ($gender == 'X'){
+			if ($related) {
+				$fillcolor = $this->colors["colorx"];
+			} else  {
+				$fillcolor = $this->colors["colorx_nr"];
 			}
 		} else {
 			if ($related) {


### PR DESCRIPTION
This commit brings support for gender "Other" (X). Individuals gender "Other" will be shown in the same shade of yellow that webtrees uses. Unknown gender individuals are now green by default, the same shade as webtrees uses.

Resolves #29 