### PR TITLE
Hide photos if disabled

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -219,8 +219,7 @@ class Dot {
 	private function isPhotoRequired(): bool
 	{
 		return ($this->isTreePreferenceShowingThumbnails($this->tree) &&
-			($this->settings["diagram_type"] == "deco-photo" ||
-				$this->settings["diagram_type_combined_with_photo"]));
+			($this->settings["diagram_type_combined_with_photo"]));
 	}
 
 	function createIndiList () {
@@ -749,7 +748,7 @@ class Dot {
 			// First row (photo & name)
 			$out .= "<TR>";
 			// Show photo
-			if (($this->settings["diagram_type"] == "deco-photo" || $this->settings["diagram_type_combined_with_photo"]) && isset($this->individuals[$pid]["pic"]) && !empty($this->individuals[$pid]["pic"])) { #ESL!!! 20090213 deco-photo not used anymore
+			if (($this->settings["diagram_type_combined_with_photo"]) && isset($this->individuals[$pid]["pic"]) && !empty($this->individuals[$pid]["pic"])) {
 				$out .= "<TD ROWSPAN=\"2\" CELLPADDING=\"1\" PORT=\"pic\" WIDTH=\"" . ($this->font_size * 5) . "\" HEIGHT=\"" . ($this->font_size * 6) . "\" FIXEDSIZE=\"true\"><IMG SCALE=\"true\" SRC=\"" . $this->individuals[$pid]["pic"] . "\" /></TD>";
 			}
 			// Show name
@@ -993,7 +992,7 @@ class Dot {
 		}
 
 		// Add photo
-		if ($this->settings["diagram_type"] == "deco-photo" || $this->settings["diagram_type_combined_with_photo"]) { #ESL!!! 20090213 deco-photo not used anymore
+		if ($this->settings["diagram_type_combined_with_photo"] && $this->isPhotoRequired()) {
 			$this->individuals[$pid]["pic"] = $this->addPhotoToIndi($pid);
 		}
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -223,20 +223,31 @@ use Fisharebest\Webtrees\Session;
             <div class="col-sm-8 wt-page-options-value">
                 <div class="row">
                     <div class="col-auto mx-3">
-                        <input type="radio" name="vars[diagtype]" id="vars[diagtype]_simple" value="simple" <?= $vars["diagtype"] == "simple" ? 'checked' : '' ?>>
+                        <input type="radio" onclick="togglePhotos(false)" name="vars[diagtype]" id="vars[diagtype]_simple" value="simple" <?= $vars["diagtype"] == "simple" ? 'checked' : '' ?>>
                         <label for="vars[diagtype]_simple"><?= I18N::translate('Simple') ?></label>
                     </div>
                     <div class="col-auto mx-3">
-                        <input type="radio" name="vars[diagtype]" id="vars[diagtype]_decorated" value="decorated" <?= $vars["diagtype"] == "decorated" ? 'checked' : '' ?>>
+                        <input type="radio" onclick="togglePhotos(true)" name="vars[diagtype]" id="vars[diagtype]_decorated" value="decorated" <?= $vars["diagtype"] == "decorated" ? 'checked' : '' ?>>
                         <label for="vars[diagtype]_decorated"><?= I18N::translate('Decorated') ?></label>
                     </div>
                     <div class="col-auto mx-3">
-                        <input type="radio" name="vars[diagtype]" id="vars[diagtype]_combined" value="combined" <?= $vars["diagtype"] == "combined" ? 'checked' : '' ?>>
+                        <input type="radio" onclick="togglePhotos(true)" name="vars[diagtype]" id="vars[diagtype]_combined" value="combined" <?= $vars["diagtype"] == "combined" ? 'checked' : '' ?>>
                         <label for="vars[diagtype]_combined"><?= I18N::translate('Combined') ?></label>
                     </div>
                 </div>
             </div>
         </div>
+
+        <? if ($tree->getPreference('SHOW_HIGHLIGHT_IMAGES') == '1') { ?>
+            <div class="row form-group">
+                <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[with_photos]"><?= I18N::translate('Add photos') ?></label>
+                <div class="col-sm-8 wt-page-options-value">
+                    <input type="hidden" name="vars[with_photos]" value="no">
+                    <input type="checkbox" name="vars[with_photos]" id="vars[with_photos]" value="with_photos" <?= $vars["with_photos"] == "with_photos" ? 'checked' : '' ?>>
+                    <span class="text-muted">(<?= I18N::translate('Only Decorated or Combined') ?>)</span>
+                </div>
+            </div>
+        <? } ?>
 
         <div class="row form-group">
             <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[show_url]"><?= I18N::translate('Add URL to individuals and families') ?></label>
@@ -356,17 +367,6 @@ use Fisharebest\Webtrees\Session;
                 <input type="checkbox" name="vars[show_mp]" id="vars[show_mp]" value="show_mp" <?= $vars["show_mp"] == "show_mp" ? 'checked' : '' ?>>
             </div>
         </div>
-
-        <? if ($tree->getPreference('SHOW_HIGHLIGHT_IMAGES') == '1') { ?>
-        <div class="row form-group">
-            <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[with_photos]"><?= I18N::translate('Add photos') ?></label>
-            <div class="col-sm-8 wt-page-options-value">
-                <input type="hidden" name="vars[with_photos]" value="no">
-                <input type="checkbox" name="vars[with_photos]" id="vars[with_photos]" value="with_photos" <?= $vars["with_photos"] == "with_photos" ? 'checked' : '' ?>>
-                <span class="text-muted">(<?= I18N::translate('Only Decorated or Combined') ?>)</span>
-            </div>
-        </div>
-        <? } ?>
 
         <div class="row form-group">
             <label class=" col-sm-4 col-form-label wt-page-options-label" for="vars[grdir]"><?= I18N::translate('Number of iterations (MCLIMIT)') ?></label>
@@ -593,30 +593,13 @@ use Fisharebest\Webtrees\Session;
             document.querySelector('.sidebar').hidden ? showSidebar(e) : hideSidebar(e);
         }
     });
-    // this function is not called anywhere on the page - what does it do? Commenting out for now, will delete
-    // later once I'm confident it's not needed.
-    /*
-    function machSVGGut(svg) {
-        [].forEach.call(svg.querySelectorAll("g>a"), function(a) {
-            var box = a.parentNode.parentNode;
-            var polygon = box.querySelector('polygon');
-            if (!polygon) {
-                return;
-            }
-            var lowerRight = polygon.getAttribute('points').split(' ')[3].split(',')
-            var menu = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
-            var dropdown = document.importNode(document.getElementById('dropdown').content, true);
-            menu.appendChild(dropdown);
-            box.appendChild(menu);
-            var bb = box.querySelector('.btn').getBoundingClientRect();
-            menu.setAttribute('class', 'node');
-            menu.setAttribute('x', parseFloat(lowerRight[0]) - bb.width + 5);
-            menu.setAttribute('y', parseFloat(lowerRight[1]) - bb.height + 5);
-            menu.setAttribute('width', bb.width);
-            menu.setAttribute('height', bb.height);
-            menu.style = 'overflow: visible';
-        });
-    } */
+
+    // Enable or disable the option to add photos.
+    // This is used when selecting diagram type, as only
+    // some types support photos.
+    function togglePhotos(enable) {
+        document.getElementById("vars[with_photos]").disabled = !enable;
+    }
 </script>
 
 <template id=dropdown>

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -2,7 +2,6 @@
 
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Session;
-use vendor\WebtreesModules\gvexport\functionsClippingsCart;
 ?>
 
 <h2 class="wt-page-title">
@@ -358,6 +357,7 @@ use vendor\WebtreesModules\gvexport\functionsClippingsCart;
             </div>
         </div>
 
+        <? if ($tree->getPreference('SHOW_HIGHLIGHT_IMAGES') == '1') { ?>
         <div class="row form-group">
             <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[with_photos]"><?= I18N::translate('Add photos') ?></label>
             <div class="col-sm-8 wt-page-options-value">
@@ -366,6 +366,7 @@ use vendor\WebtreesModules\gvexport\functionsClippingsCart;
                 <span class="text-muted">(<?= I18N::translate('Only Decorated or Combined') ?>)</span>
             </div>
         </div>
+        <? } ?>
 
         <div class="row form-group">
             <label class=" col-sm-4 col-form-label wt-page-options-label" for="vars[grdir]"><?= I18N::translate('Number of iterations (MCLIMIT)') ?></label>


### PR DESCRIPTION
For each tree in webtrees there is an option in the control panel indicating if thumbnails should be shown in charts. If this is set to "Hidden", the option to include photos is not shown.

This pull request also includes a UI enhancement where if you select the "Simple" diagram type, the option to include photos is disabled. Selecting another type re-enables the box.

Resolves #54 