### PR TITLE
Warn if GraphViz not installed

### DIFF
--- a/config.php
+++ b/config.php
@@ -39,13 +39,20 @@ $GVE_CONFIG["graphviz_bin"] = "/usr/bin/dot"; // Default on Debian Linux
 
 $GVE_CONFIG["filename"] = "gvexport";
 
+// Test we can actually access GraphViz
+exec($GVE_CONFIG["graphviz_bin"] . " -V"." 2>&1", $stdout_output, $return_var);
+if ($return_var !== 0)
+{
+	$GVE_CONFIG["graphviz_bin"] = "";
+}
+
 // Output file formats
 $GVE_CONFIG["output"]["dot"]["label"] = "DOT"; #ESL!!! 20090213
 $GVE_CONFIG["output"]["dot"]["extension"] = "dot";
 $GVE_CONFIG["output"]["dot"]["exec"] = "";
 $GVE_CONFIG["output"]["dot"]["cont_type"] = "text/plain; charset=utf-8";
 
-if ( !empty( $GVE_CONFIG["graphviz_bin"])) {
+if ( !empty( $GVE_CONFIG["graphviz_bin"]) && $GVE_CONFIG["graphviz_bin"] != "") {
 	$GVE_CONFIG["output"]["png"]["label"] = "PNG"; #ESL!!! 20090213
 	$GVE_CONFIG["output"]["png"]["extension"] = "png";
 	$GVE_CONFIG["output"]["png"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tpng -o" . $GVE_CONFIG["filename"] . ".png " . $GVE_CONFIG["filename"] . ".dot";

--- a/module.php
+++ b/module.php
@@ -191,6 +191,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 			'gve_config' => $GVE_CONFIG,
             'cartempty' => !functionsClippingsCart::isIndividualInCart($tree),
 			'module' => $this,
+            'nographviz' => $GVE_CONFIG["graphviz_bin"] == ""
 		]);
 	}
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -462,19 +462,9 @@ use Fisharebest\Webtrees\Session;
             <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[otype]"><?= I18N::translate('Output File Type') ?></label>
             <div class="col-sm-8 wt-page-options-value">
                 <?= view('components/select', ['name' => 'vars[otype]', 'selected' => $vars['otype'], 'options' => $otypes]) ?>
-                <small id="emailHelp" class="form-text text-muted"><?= I18N::translate("Choose DOT if you don't have GraphViz installed on server.") ?></small>
+                <small id="emailHelp" class="form-text text-muted"><?= $nographviz ? I18N::translate("Options limited as GraphViz not installed on server") : "" ?></small>
             </div>
         </div>
-
-        <!--
-    <div class="row form-group">
-        <label class="col-sm-4 col-form-label wt-page-options-label" for="pagebrk_var">Use Page Break</label>
-        <div class="col-sm-8 wt-page-options-value">
-            <input type="checkbox" name="vars[pagebrk]" id="pagebrk_var" value="pagebrk">
-        </div>
-    </div>
-    -->
-
 
     </div>
 


### PR DESCRIPTION
Only lets you choose DOT as an output format, and gives a message warning that GraphViz is not installed so options are limited.
As client side generation is added, this should still be suitable.

Resolves #76 