### PR TITLE
Respect XREF setting in Vesta

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -698,9 +698,10 @@ class Dot {
 				$name = str_replace(array('<span class="starredname">', '</span>'), array('<FONT face="' . $this->settings["fontname"] . ' italic">', '</FONT>'), $name);
 			}
 
+			// If PID already in name (from another module), remove it so we don't add twice
+			$name = str_replace(" (" . $pid . ")", "", $name);
+
 			if ($this->settings["show_pid"]) {
-				// If PID already in name (from another module), remove it
-				$name = str_replace(" (" . $pid . ")", "", $name);
 				// Show INDI id
 				$name = $name . " (" . $pid . ")";
 			}

--- a/module.php
+++ b/module.php
@@ -151,7 +151,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 			"indispou" => "spou",
 			"marknr" => "marknr",
 			"show_url" => "show_url",
-			"show_pid" => "",
+			"show_pid" => "DEFAULT", // This is set to DEFAULT so we can tell if it was loaded from cookie or not
 			"show_fid" => "",
 			"use_abbr_place" => "Full place name",
 			"debug" => ($GVE_CONFIG['debug'] ? "debug" : ""),

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -92,6 +92,18 @@ use Fisharebest\Webtrees\Session;
             }
         </script>
         <?php
+        /* Check if another module (e.g. vesta classic) is adding the XREF to
+           the name. If so, we want to enable the XREF option for individuals
+           unless we already have a saved setting */
+        $individual = $module->getIndividual($tree, $_GET["xref"]);
+        $startName = $individual->fullName();
+        $name = str_replace(" (" . $_GET["xref"] . ")", "", $startName);
+        if ($startName != $name && $vars["show_pid"] == "DEFAULT") {
+            $overridePID = true;
+        } else {
+            $overridePID = false;
+        }
+        
         // Check if the clippings cart is empty, to decide what options to allow
         $cart = Session::get('cart', []);
         $xrefs = array_keys($cart[$tree->name()] ?? []);
@@ -279,7 +291,7 @@ use Fisharebest\Webtrees\Session;
             <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[show_pid]"><?= I18N::translate('Show Individual ID') ?></label>
             <div class="col-sm-8 wt-page-options-value">
                 <input type="hidden" name="vars[show_pid]" value="no">
-                <input type="checkbox" name="vars[show_pid]" id="vars[show_pid]" value="show_pid" <?= $vars["show_pid"] == "show_pid" ? 'checked' : '' ?>>
+                <input type="checkbox" name="vars[show_pid]" id="vars[show_pid]" value="show_pid" <?= $vars["show_pid"] == "show_pid" || $overridePID ? 'checked' : '' ?>>
             </div>
         </div>
 


### PR DESCRIPTION
When using the Vesta suite of modules, you can enable an option to show the XREF in the person's name. This means the option to show XREF no longer works.
In this commit, we make a change so that the GVExport option will successfully disable this, but we also change it so that if the option to show XREF in name is enabled in Vesta (or another similar module), then the option to display the XREF on individuals is turned on by default (otherwise it is off by default).

Resolves #91