### PR TITLE
Fix clippings cart options

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -106,15 +106,7 @@ use Fisharebest\Webtrees\Tree;
             <label class=" col-sm-4 col-form-label wt-page-options-label" for="pid"><?= I18N::translate('Include anyone related to') ?></label>
             <div class="col-sm-8 wt-page-options-value">
                 <div class="cart_toggle_hide" <?php if ($greypeople) { echo 'style="display: none"'; } ?>>
-                <?php
-                if ($cartempty) {
-                    echo view('components/select-individual', ['name' => 'pid', 'id' => 'pid', 'tree' => $tree, 'individual' => $individual]);
-                } else { ?>
-                    <div style="display: none">
-                        <?= view('components/select-individual', ['name' => 'pid', 'id' => 'pid', 'tree' => $tree, 'individual' => $individual]); ?>
-                    </div>
-                    <input type="text" class="form-control" disabled />
-                <?php } ?>
+                    <?= view('components/select-individual', ['name' => 'pid', 'id' => 'pid', 'tree' => $tree, 'individual' => $individual]); ?>
                 </div>
                 <div class="input-group mt-1">
                     <input class="cart_toggle" type="text" class="form-control" name="vars[other_pids]" id="vars[other_pids]" value="<?= $vars['other_pids'] ?>" <?= $greypeople ? "disabled" : ""; ?>>


### PR DESCRIPTION
When items in clippings cart, the option to ignore was not working as when branches had been merged some of the old code was merged in. This resolves the issue.