### PR TITLE
Update related checking to improve accuracy

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -347,6 +347,7 @@ class Dot {
 				foreach ($this->individuals as $indi) {
 					if (!$indi['rel']) {
 						$NonrelativeExists = TRUE;
+						break;
 					}
 				}
 				// If there are non-related persons, generate a full relative tree starting from

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -316,19 +316,20 @@ class Dot {
 		}
 		return $adopfamcadoptype;
 	}
-	function createIndiList () {
+
+	function createIndiList (&$individuals, $full) {
 		if ($this->settings["multi_indi"] == FALSE) {
-			$this->addIndiToList("Start | Code 15", $this->settings["indi"], $this->indi_search_method["ance"], $this->indi_search_method["desc"], $this->indi_search_method["spou"], $this->indi_search_method["sibl"], TRUE, 0, 0);
+			$this->addIndiToList("Start | Code 15", $this->settings["indi"], $this->indi_search_method["ance"], $this->indi_search_method["desc"], $this->indi_search_method["spou"], $this->indi_search_method["sibl"], TRUE, 0, 0, $individuals, $full);
 		} else {
 			// if multiple indis are defined
 			$indis = explode(",", $this->settings["indi"]);
 			for ($i=0;$i<count($indis);$i++) {
-				$this->addIndiToList("Start | Code 16", trim($indis[$i]), $this->indi_search_method["ance"], $this->indi_search_method["desc"], $this->indi_search_method["spou"], $this->indi_search_method["sibl"], TRUE, 0, 0);
+				$this->addIndiToList("Start | Code 16", trim($indis[$i]), $this->indi_search_method["ance"], $this->indi_search_method["desc"], $this->indi_search_method["spou"], $this->indi_search_method["sibl"], TRUE, 0, 0, $individuals, $full);
 			}
 		}
 		// -- DEBUG ---
 		if ($this->settings["debug"]) {
-			$this->printDebug("Finished individuals list: ".print_r($this->individuals), $ind);
+			$this->printDebug("Finished individuals list: ".print_r($individuals), $ind);
 		}
 		// -------------
 	}
@@ -336,7 +337,7 @@ class Dot {
 	function createDOTDump() {
 		// If no individuals in the clippings cart (or option chosen to overide), use standard method
 		if (!functionsClippingsCart::isIndividualInCart($this->tree) || !$this->settings["usecart"] ) {
-			$this->createIndiList();
+			$this->createIndiList($this->individuals, false);
 		} else {
 		// If individuals in clipping cart and option chosen to use them, then proceed
 			$functionsCC = new functionsClippingsCart($this->tree, $this->isPhotoRequired(), ($this->settings["diagram_type"] == "combined"));
@@ -1034,23 +1035,27 @@ class Dot {
 	/**
 	 * Adds an individual to the indi list
 	 *
-	 * @param string $pid
-	 * @param boolean $ance
-	 * @param boolean $desc
-	 * @param boolean $spou
-	 * @param boolean $sibl
-	 * @param boolean $rel
+	 * @param string $pid XREF of individual to add
+	 * @param boolean $ance whether to include ancestors when adding this individual
+	 * @param boolean $desc whether to include descendants when adding this individual
+	 * @param boolean $spou whether to include spouses when adding this individual
+	 * @param boolean $sibl whether to add siblings when adding this individual
+	 * @param boolean $rel whether to treat this individual as related
+	 * @param integer $ind indent level - used for debug output
+	 * @param integer $level the current generation - 0 is starting generation, negative numbers are descendants, positive are ancestors
+	 * @param array $individuals array of individuals to be updated (passed by referrence)
+	 * @param boolean $full whether we are scanning full tree of relatives, ignoring settings
 	 */
-	function addIndiToList($sourcePID, $pid, $ance = FALSE, $desc = FALSE, $spou = FALSE, $sibl = FALSE, $rel = TRUE, $ind = 0, $level = 0) {
+	function addIndiToList($sourcePID, $pid, $ance = FALSE, $desc = FALSE, $spou = FALSE, $sibl = FALSE, $rel = TRUE, $ind = 0, $level = 0, &$individuals, $full) {
 		global $GVE_CONFIG, $pgv_changes, $GEDCOM;
 		$ance_level = $this->indi_search_method["ance"] ? $this->settings["ance_level"] : 0;
 		$desc_level = $this->indi_search_method["desc"] ? $this->settings["desc_level"] : 0;
 
-		$this->individuals[$pid]['pid'] = $pid;
+		$individuals[$pid]['pid'] = $pid;
 
 		// Overwrite the 'related' status if it was not set before or it's 'false' (for those people who are added as both related and non-related)
-		if (!isset($this->individuals[$pid]['rel']) || ($this->individuals[$pid]['rel'] == FALSE && $rel)) {
-			$this->individuals[$pid]['rel'] = $rel;
+		if (!isset($individuals[$pid]['rel']) || ($individuals[$pid]['rel'] == FALSE && $rel)) {
+			$individuals[$pid]['rel'] = $rel;
 		} else {
 			return false;
 		}
@@ -1068,7 +1073,7 @@ class Dot {
 		// -------------
 		// Add photo
 		if ($this->settings["diagram_type_combined_with_photo"] && $this->isPhotoRequired()) {
-			$this->individuals[$pid]["pic"] = $this->addPhotoToIndi($pid);
+			$individuals[$pid]["pic"] = $this->addPhotoToIndi($pid);
 		}
 
 		// Get updated INDI data
@@ -1087,7 +1092,7 @@ class Dot {
 
 				foreach ($fams as $fam) {
 					$fid = $fam->xref();
-					$this->individuals[$pid]["fams"][$fid] = $fid;
+					$individuals[$pid]["fams"][$fid] = $fid;
 
 					//$this->families[$fid]["husb_id"] = $fam->getHusbId();
 					//$this->families[$fid]["wife_id"] = $fam->wifeId();
@@ -1127,7 +1132,7 @@ class Dot {
 				}
 			} else {
 				// If there is no spouse family we create a dummy one
-				$this->individuals[$pid]["fams"]["F_$pid"] = "F_$pid";
+				$individuals[$pid]["fams"]["F_$pid"] = "F_$pid";
 				$this->addFamToList("F_$pid");
 
 				// --- DEBUG ---
@@ -1246,7 +1251,7 @@ class Dot {
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 1", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1);
+								$this->addIndiToList($pid."|Code 1", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $full);
 							} else {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
@@ -1254,7 +1259,7 @@ class Dot {
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 2", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"], $this->indi_search_method["sibl"], $rel, $ind, $level+1);
+								$this->addIndiToList($pid."|Code 2", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"], $this->indi_search_method["sibl"], $rel, $ind, $level+1, $individuals, $full);
 							}
 						}
 						if (!empty($wife_id)) {
@@ -1268,7 +1273,7 @@ class Dot {
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 3", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1);
+								$this->addIndiToList($pid."|Code 3", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $full);
 							} else {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
@@ -1276,13 +1281,13 @@ class Dot {
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 4", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"], $this->indi_search_method["sibl"], $rel, $ind, $level+1);
+								$this->addIndiToList($pid."|Code 4", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"], $this->indi_search_method["sibl"], $rel, $ind, $level+1, $individuals, $full);
 							}
 						}
 
 						if ($this->settings["diagram_type"] == "combined") {
 							// This person's spouse family HAS parents
-							foreach ($this->individuals[$pid]["fams"] as $s_fid=>$s_fam) {
+							foreach ($individuals[$pid]["fams"] as $s_fid=>$s_fam) {
 								$this->families[$s_fid]["has_parents"] = TRUE;
 							}
 						}
@@ -1291,7 +1296,7 @@ class Dot {
 				} else {
 					if ($this->settings["diagram_type"] == "combined") {
 						// This person's spouse family HAS NO parents
-						foreach ($this->individuals[$pid]["fams"] as $s_fid=>$s_fam) {
+						foreach ($individuals[$pid]["fams"] as $s_fid=>$s_fam) {
 							if (!isset($this->families[$s_fid]["has_parents"])) {
 								$this->families[$s_fid]["has_parents"] = FALSE;
 							}
@@ -1380,9 +1385,9 @@ class Dot {
 							}
 
 							if ($this->indi_search_method["any"]) {
-								$this->addIndiToList($pid."|Code 14", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, FALSE, $ind, $level-1);
+								$this->addIndiToList($pid."|Code 14", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, FALSE, $ind, $level-1, $individuals, $full);
 							}
-							$this->addIndiToList($pid."|Code 5", $child_id, FALSE, TRUE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level-1);
+							$this->addIndiToList($pid."|Code 5", $child_id, FALSE, TRUE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level-1, $individuals, $full);
 
 						}
 					}
@@ -1457,9 +1462,9 @@ class Dot {
 						// -------------
 
 						if ($this->settings["mark_not_related"] == TRUE) {
-							$this->addIndiToList($pid."|Code 6", $spouse_id, $this->indi_search_method["any"] && $ance, $this->indi_search_method["any"] && $desc, $this->indi_search_method["any"], $this->indi_search_method["any"], FALSE, $ind, $level);
+							$this->addIndiToList($pid."|Code 6", $spouse_id, $this->indi_search_method["any"] && $ance, $this->indi_search_method["any"] && $desc, $this->indi_search_method["any"], $this->indi_search_method["any"], FALSE, $ind, $level, $individuals, $full);
 						} else {
-							$this->addIndiToList($pid."|Code 7", $spouse_id, $this->indi_search_method["any"], $this->indi_search_method["any"], $this->indi_search_method["any"], $this->indi_search_method["any"], TRUE, $ind, $level);
+							$this->addIndiToList($pid."|Code 7", $spouse_id, $this->indi_search_method["any"], $this->indi_search_method["any"], $this->indi_search_method["any"], $this->indi_search_method["any"], TRUE, $ind, $level, $individuals, $full);
 						}
 					}
 
@@ -1524,9 +1529,9 @@ class Dot {
 
 							// If searching for cousins, then the descendants of ancestors' siblings should be added
 							if ($this->indi_search_method["cous"]) {
-								$this->addIndiToList($pid."|Code 8", $child_id, TRUE, TRUE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level);
+								$this->addIndiToList($pid."|Code 8", $child_id, TRUE, TRUE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level, $individuals, $full);
 							} else {
-								$this->addIndiToList($pid."|Code 9", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level);
+								$this->addIndiToList($pid."|Code 9", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, $related, $ind, $level, $individuals, $full);
 							}
 
 						}
@@ -1573,9 +1578,9 @@ class Dot {
 
 							// If searching for step-cousins, then the descendants of ancestors' siblings should be added
 							if ($this->indi_search_method["cous"]) {
-								$this->addIndiToList($pid."|Code 10", $child_id, FALSE, TRUE, $this->indi_search_method["spou"], FALSE, $rel, $ind, $level);
+								$this->addIndiToList($pid."|Code 10", $child_id, FALSE, TRUE, $this->indi_search_method["spou"], FALSE, $rel, $ind, $level, $individuals, $full);
 							} else {
-								$this->addIndiToList($pid."|Code 11", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, $rel, $ind, $level);
+								$this->addIndiToList($pid."|Code 11", $child_id, TRUE, FALSE, $this->indi_search_method["spou"], FALSE, $rel, $ind, $level, $individuals, $full);
 							}
 						}
 					}
@@ -1590,7 +1595,6 @@ class Dot {
 			$this->printDebug("}\n", $ind);
 		}
 		// -------------
-
 	}
 
 	/**

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1192,7 +1192,7 @@ class Dot {
 			}
 		}
 
-		if (!$stop_proc)
+		if (!$stop_proc || $full)
 		{
 
 			// Add ancestors (parents)


### PR DESCRIPTION
Currently, when the related option is set, this only checks the displayed records. Where the link is not in the displayed records, the related status is shown as not related. This update will scan the full tree for relatives of starting persons, in order to determine whether an individual is related to the starting person.

Resolves #109 and may resolve several other issues.