### PR TITLE
Tidy hover text

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -587,8 +587,21 @@ use Fisharebest\Webtrees\Tree;
                 images: images
             });
         }).then(function (element) {
+            // Now we have to clean up the generated SVG.
+
+            // remove title tags so we don't get weird data on hover,
+            // instead this defaults to the XREF of the record
+            const a = element.getElementsByTagName("a");
+            for (let i = 0; i < a.length; i++) {
+                a[i].removeAttribute("xlink:title");
+            }
+            //half of bug fix for photos not showing in browser - we change & to %26 in functions_dot.php
+            element.innerHTML = element.innerHTML.replaceAll("%26", "&amp;");
+            // Don't show anything when hovering on blank space
+            element.innerHTML = element.innerHTML.replaceAll("<title>WT_Graph</title>", "");
+
             console.log("Appending SVG", element);
-            element.innerHTML = element.innerHTML.replaceAll("%26", "&amp;"); //half of bug fix for photos not showing in browser - we change & to %26 in functions_dot.php
+            // Clear current rendering then append new element to the page
             rendering.innerHTML = "";
             rendering.appendChild(element);
             var fullZoom = Math.min(2, rendering.getBoundingClientRect().width / element.getBBox().width);


### PR DESCRIPTION
When hovering over a family record, a messy version of the contents of the record was shown. When hovering over a URL on an individual, it showed "<TABLE>". It also showed "WT_Graph" when hovering in blank space. This now shows nothing when in blank space, and the XREF of the record when hovering over a record.