### PR TITLE
Add client side image download

### DIFF
--- a/config.php
+++ b/config.php
@@ -51,32 +51,35 @@ if (!is_exec_available() || $return_var !== 0)
 }
 
 // Output file formats
+$GVE_CONFIG["output"]["svg"]["label"] = "SVG"; #ESL!!! 20090213
+$GVE_CONFIG["output"]["svg"]["extension"] = "svg";
+$GVE_CONFIG["output"]["svg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tsvg:cairo -o" . $GVE_CONFIG["filename"] . ".svg " . $GVE_CONFIG["filename"] . ".dot";
+$GVE_CONFIG["output"]["svg"]["cont_type"] = "image/svg+xml";
+$GVE_CONFIG["output"]["svg"]["rewrite_media_paths"] = true;
+
+
 $GVE_CONFIG["output"]["dot"]["label"] = "DOT"; #ESL!!! 20090213
 $GVE_CONFIG["output"]["dot"]["extension"] = "dot";
 $GVE_CONFIG["output"]["dot"]["exec"] = "";
 $GVE_CONFIG["output"]["dot"]["cont_type"] = "text/plain; charset=utf-8";
 
-if ( !empty( $GVE_CONFIG["graphviz_bin"]) && $GVE_CONFIG["graphviz_bin"] != "") {
-	$GVE_CONFIG["output"]["png"]["label"] = "PNG"; #ESL!!! 20090213
-	$GVE_CONFIG["output"]["png"]["extension"] = "png";
-	$GVE_CONFIG["output"]["png"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tpng -o" . $GVE_CONFIG["filename"] . ".png " . $GVE_CONFIG["filename"] . ".dot";
-	$GVE_CONFIG["output"]["png"]["cont_type"] = "image/png";
+$GVE_CONFIG["output"]["png"]["label"] = "PNG"; #ESL!!! 20090213
+$GVE_CONFIG["output"]["png"]["extension"] = "png";
+$GVE_CONFIG["output"]["png"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tpng -o" . $GVE_CONFIG["filename"] . ".png " . $GVE_CONFIG["filename"] . ".dot";
+$GVE_CONFIG["output"]["png"]["cont_type"] = "image/png";
 
-	$GVE_CONFIG["output"]["jpg"]["label"] = "JPG"; #ESL!!! 20090213
-	$GVE_CONFIG["output"]["jpg"]["extension"] = "jpg";
-	$GVE_CONFIG["output"]["jpg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tjpg -o" . $GVE_CONFIG["filename"] . ".jpg " . $GVE_CONFIG["filename"] . ".dot";
-	$GVE_CONFIG["output"]["jpg"]["cont_type"] = "image/jpeg";
+$GVE_CONFIG["output"]["jpg"]["label"] = "JPG"; #ESL!!! 20090213
+$GVE_CONFIG["output"]["jpg"]["extension"] = "jpg";
+$GVE_CONFIG["output"]["jpg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tjpg -o" . $GVE_CONFIG["filename"] . ".jpg " . $GVE_CONFIG["filename"] . ".dot";
+$GVE_CONFIG["output"]["jpg"]["cont_type"] = "image/jpeg";
+
+
+if ( !empty( $GVE_CONFIG["graphviz_bin"]) && $GVE_CONFIG["graphviz_bin"] != "") {
 
 	$GVE_CONFIG["output"]["gif"]["label"] = "GIF"; #ESL!!! 20090213
 	$GVE_CONFIG["output"]["gif"]["extension"] = "gif";
 	$GVE_CONFIG["output"]["gif"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tgif -o" . $GVE_CONFIG["filename"] . ".gif " . $GVE_CONFIG["filename"] . ".dot";
 	$GVE_CONFIG["output"]["gif"]["cont_type"] = "image/gif";
-
-	$GVE_CONFIG["output"]["svg"]["label"] = "SVG"; #ESL!!! 20090213
-	$GVE_CONFIG["output"]["svg"]["extension"] = "svg";
-	$GVE_CONFIG["output"]["svg"]["exec"] = $GVE_CONFIG["graphviz_bin"] . " -Tsvg:cairo -o" . $GVE_CONFIG["filename"] . ".svg " . $GVE_CONFIG["filename"] . ".dot";
-	$GVE_CONFIG["output"]["svg"]["cont_type"] = "image/svg+xml";
-	$GVE_CONFIG["output"]["svg"]["rewrite_media_paths"] = true;
 
 	$GVE_CONFIG["output"]["pdf"]["label"] = "PDF"; #ESL!!! 20090213
 	$GVE_CONFIG["output"]["pdf"]["extension"] = "pdf";

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -478,6 +478,8 @@ use Fisharebest\Webtrees\Tree;
 </div>
 
 <script type="text/javascript">
+    const graphvizAvailable = <?= $nographviz ? "false" : "true" ?>;
+
     var workerURL = '<?= $module->assetUrl('javascript/full.renderer.js'); ?>';
     var viz = new Viz({
         workerURL: workerURL
@@ -488,9 +490,7 @@ use Fisharebest\Webtrees\Tree;
 
     document.addEventListener("DOMContentLoaded", function(e) {
         // Load browser render when page has loaded
-        // Timeout needed as function is in file added to page
-        // by javascript so doesn't exist the instant page loads.
-        setTimeout(updateRender,5);
+        updateRender();
         // Remove reset parameter from URL when page loaded, to prevent
         // further resets when page reloaded
         let url=document.location.href.split("?")[0];
@@ -513,13 +513,35 @@ use Fisharebest\Webtrees\Tree;
         e.preventDefault();
     });
 
-    // If "Download" button clicked, first check that individual has been selected
+    // If "Download" button clicked
     document.querySelector('.main-action').addEventListener('click', function(e) {
+        // first check that individual has been selected
         if (checkIndiBlank() === false) {
             removeError("indi-error");
         } else {
             addError("indi-error","<?= I18N::translate("Individual required") ?>");
             e.preventDefault();
+        }
+
+        // Also check if GraphViz installed. If so then let it handle it,
+        // but if not, trigger client side actions
+        if (!graphvizAvailable) {
+            output = document.getElementById('vars[otype]').value;
+            switch(output) {
+                case "png":
+                    downloadSVGAsPNG();
+                    break;
+                case "svg":
+                    downloadSVGAsText();
+                    break;
+                case "jpg":
+                    downloadSVGAsJPEG();
+                    break;
+                default:
+            }
+            if (output !== "dot") {
+                e.preventDefault();
+            }
         }
     });
 


### PR DESCRIPTION
Add ability to download some image formats via client side javascript. Check for GraphViz installation, if installed use this, otherwise use client side.

Includes SVG, PNG, JPEG options.

Resolves #23  and #25 