### PR TITLE
Fix foster child showing as blood related

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -311,24 +311,19 @@ class Dot {
 					}
 				}
 			}
-			// Find foster relationships between records
-			$gedcom = $fact->gedcom();
-			if (substr_count($gedcom, "2 PEDI FOSTER") > 0) {
-				$adop = preg_split("/\n/", $gedcom);
-				foreach ($adop as $line) {
-					if (substr_count($line, "1 FAMC") > 0) {
-						$fosterFAMCLine = explode("@", $line);
-						$adopfamid = $fosterFAMCLine[1];
+			// Find other relationships between records
+			foreach ($facts as $fact) {
+				$gedcom =  strtoupper($fact->gedcom());
+				if (substr_count($gedcom, "2 PEDI") > 0 && substr_count($gedcom, "2 PEDI BIRTH") == 0) {
+					$adop = preg_split("/\n/", $gedcom);
+					foreach ($adop as $line) {
+						if (substr_count($line, "1 FAMC") > 0) {
+							$adopfamid = explode("@", $line)[1];
 
-						// Adopter family found
-						if ($adopfamid == $fid) {
-							$adopfamcadoptype = "FOSTER";
-							// ---DEBUG---
-							if ($this->settings["debug"]) {
-								$this->printDebug("(".$i->xref().") -- FOSTER record: " . preg_replace("/\n/", " | ", $gedcom) . "\n", $ind);
+							// Adopter family found
+							if ($adopfamid == $fid) {
+								$adopfamcadoptype = "OTHER";
 							}
-							// -----------
-							break;
 						}
 					}
 				}

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1253,9 +1253,9 @@ class Dot {
 						$f = $this->getUpdatedFamily($fid);
 
 						// First check if we are related to our own family
-						$adopfamcadoptype = $this->getRelationshipType($i, $f, $ind);
+						$relationshipType = $this->getRelationshipType($i, $f, $ind);
 						// Not related - so overide the initial setting
-						if ($adopfamcadoptype != "") {
+						if ($relationshipType != "") {
 							$rel = false;
 						}
 
@@ -1280,7 +1280,7 @@ class Dot {
 						}
 
 						// Work out if indi has adoptive relationship to this family
-						$adopfamcadoptype = $this->getRelationshipType($i, $fam, $ind);
+						$relationshipType = $this->getRelationshipType($i, $fam, $ind);
 						// Add father & mother
 						$h = $f->husband();
 						$w = $f->wife();
@@ -1297,14 +1297,14 @@ class Dot {
 							$families[$fid]["has_children"] = TRUE;
 							$families[$fid]["husb_id"] = $husb_id;
 
-							if ($adopfamcadoptype == "BOTH" || $adopfamcadoptype == "HUSB") {
+							if ($relationshipType == "BOTH" || $relationshipType == "HUSB") {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
 									$this->printDebug("($pid) -- adding an _ADOPTING_ PARENT /FATHER/ with INDI id ($husb_id) from FAM ($fid):\n", $ind);
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 1", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $families, $full, $relList);
+								$this->addIndiToList($pid."|Code 1", $husb_id, TRUE, FALSE, $this->indi_search_method["spou"] && $relationshipType !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $families, $full, $relList);
 							} else {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
@@ -1319,14 +1319,14 @@ class Dot {
 							$families[$fid]["has_children"] = TRUE;
 							$families[$fid]["wife_id"] = $wife_id;
 
-							if ($adopfamcadoptype == "BOTH" || $adopfamcadoptype == "WIFE") {
+							if ($relationshipType == "BOTH" || $relationshipType == "WIFE") {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
 									$this->printDebug("($pid) -- adding an _ADOPTING_ PARENT /MOTHER/ with INDI id ($wife_id) from FAM ($fid):\n", $ind);
 									//var_dump($fams);
 								}
 								// -------------
-								$this->addIndiToList($pid."|Code 3", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"] && $adopfamcadoptype !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $families, $full, $relList);
+								$this->addIndiToList($pid."|Code 3", $wife_id, TRUE, FALSE, $this->indi_search_method["spou"] && $relationshipType !== "BOTH", $this->indi_search_method["sibl"], FALSE, $ind, $level+1, $individuals, $families, $full, $relList);
 							} else {
 								// --- DEBUG ---
 								if ($this->settings["debug"]) {
@@ -1430,8 +1430,8 @@ class Dot {
 							// -------------
 
 							// Work out if indi has adoptive relationship to this family
-							$adopfamcadoptype = $this->getRelationshipType($child, $f, $ind);
-							if ($adopfamcadoptype != "") {
+							$relationshipType = $this->getRelationshipType($child, $f, $ind);
+							if ($relationshipType != "") {
 								$related = false;
 							} else {
 								$related = $rel;
@@ -1573,8 +1573,8 @@ class Dot {
 							// -------------
 
 							// Work out if indi has adoptive relationship to this family
-							$adopfamcadoptype = $this->getRelationshipType($child, $fam, $ind);
-							if ($adopfamcadoptype != "") {
+							$relationshipType = $this->getRelationshipType($child, $fam, $ind);
+							if ($relationshipType != "") {
 								$related = false;
 							} else {
 								$related = $rel;


### PR DESCRIPTION
This pull request updates the check so any relationship type is treated as non-relative except for "BIRTH" and not having a pedigree declared.

Resolves #140 