### PR TITLE
Fix dpi

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -187,9 +187,9 @@ function showToast(message) {
         toast.innerText = message;
         setTimeout(function () {
             toast.remove();
-        }, 5500);
+        }, 550000);
         toastParent.appendChild(toast);
-        toast.setAttribute("style", " margin-left: -"+toast.clientWidth/2 + "px");
+        toast.setAttribute("style", " margin-left: -"+toast.clientWidth/2 + "px; width:" + toast.clientWidth + "px");
         toast.className += " show";
     }
 }

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -242,7 +242,11 @@ function downloadSVGAsImage(type) {
         context.drawImage(img, 0, 0, img.width, img.height);
         // Download it
         const dataURL = canvas.toDataURL('image/'+type);
-        downloadLink(dataURL, "gvexport."+type);
+        if (dataURL.length < 10) {
+            showToast("E:"+CLIENT_ERRORS[0]); // Canvas too big
+        } else {
+            downloadLink(dataURL, "gvexport." + type);
+        }
     }
 
 }

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -185,11 +185,12 @@ function showToast(message) {
             message = message.substring(ERROR_CHAR.length);
         }
         toast.innerText = message;
-        toast.className += " show";
         setTimeout(function () {
             toast.remove();
         }, 5500);
         toastParent.appendChild(toast);
+        toast.setAttribute("style", " margin-left: -"+toast.clientWidth/2 + "px");
+        toast.className += " show";
     }
 }
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -623,6 +623,8 @@ use Fisharebest\Webtrees\Tree;
             element.innerHTML = element.innerHTML.replaceAll("%26", "&amp;");
             // Don't show anything when hovering on blank space
             element.innerHTML = element.innerHTML.replaceAll("<title>WT_Graph</title>", "");
+            // Set SVG viewBox to height/width so image is not cut off
+            element.setAttribute("viewBox", "0 0 "+element.getAttribute("width")+" "+element.getAttribute("height"));
             console.log("Appending SVG", element);
             // Clear current rendering then append new element to the page
             rendering.innerHTML = "";

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -41,7 +41,10 @@ use Fisharebest\Webtrees\Tree;
 </script>
 <script src="<?= $module->assetUrl('javascript/viz.js'); ?>"></script>
 <script src="<?= $module->assetUrl('javascript/panzoom.min.js'); ?>"></script>
-<script type="text/javascript">const cartempty = <?= $cartempty ? "true" : "false" ?>;</script>
+<script type="text/javascript">
+    const cartempty = <?= $cartempty ? "true" : "false" ?>;
+    const CLIENT_ERRORS = ["<?= I18N::translate('Your browser does not support exporting images this large. Please reduce number of records or DPI setting.') ?>"];
+</script>
 
 <h2 class="wt-page-title">
     <?= $title ?>

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -631,7 +631,7 @@ use Fisharebest\Webtrees\Tree;
             rendering.appendChild(element);
             const fullZoom = Math.min(2, rendering.getBoundingClientRect().width / element.getBBox().width);
             panzoom(element, {
-                maxZoom: 2,
+                maxZoom: 4,
                 minZoom: fullZoom / 2,
                 initialZoom: fullZoom
             });

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -43,7 +43,7 @@ use Fisharebest\Webtrees\Tree;
 <script src="<?= $module->assetUrl('javascript/panzoom.min.js'); ?>"></script>
 <script type="text/javascript">
     const cartempty = <?= $cartempty ? "true" : "false" ?>;
-    const CLIENT_ERRORS = ["<?= I18N::translate('Your browser does not support exporting images this large. Please reduce number of records or DPI setting.') ?>"];
+    const CLIENT_ERRORS = ["<?= I18N::translate('Your browser does not support exporting images this large. Please reduce number of records, reduce DPI setting, or use SVG option.') ?>"];
 </script>
 
 <h2 class="wt-page-title">

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -624,7 +624,7 @@ use Fisharebest\Webtrees\Tree;
             // Don't show anything when hovering on blank space
             element.innerHTML = element.innerHTML.replaceAll("<title>WT_Graph</title>", "");
             // Set SVG viewBox to height/width so image is not cut off
-            element.setAttribute("viewBox", "0 0 "+element.getAttribute("width")+" "+element.getAttribute("height"));
+            element.setAttribute("viewBox", "0 0 "+element.getAttribute("width").replace("pt","")+" "+element.getAttribute("height").replace("pt",""));
             console.log("Appending SVG", element);
             // Clear current rendering then append new element to the page
             rendering.innerHTML = "";

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -546,18 +546,18 @@ use Fisharebest\Webtrees\Tree;
     });
 
     function updateRender() {
-        var oldOtype = document.getElementById('vars[otype]').value;
+        const oldOtype = document.getElementById('vars[otype]').value;
         document.getElementById('vars[otype]').value = 'dot';
         // Set value to true so we can return other info with DOT file
         // that can't be included with downloaded file
         document.getElementById("browser").value = "true";
         // Enable disabled fields so they are included in serialised data - this means the values are remembered
-        var el = document.getElementsByClassName("cart_toggle");
-        for (var i = 0; i < el.length; i++) {
+        const el = document.getElementsByClassName("cart_toggle");
+        for (let i = 0; i < el.length; i++) {
             el.item(i).disabled = false;
         }
         // Get the form data
-        var data = jQuery(form).serialize();
+        const data = jQuery(form).serialize();
         // Disable our fields again by indicating cart is enabled (only if items in cart)
         if (!cartempty && document.getElementById("vars[usecart]_yes").checked) {
             toggleCart(true);
@@ -565,12 +565,12 @@ use Fisharebest\Webtrees\Tree;
         document.getElementById("browser").value = "false";
 
         document.getElementById('vars[otype]').value = oldOtype;
-        var lastDotStr, indiNum, famNum, messages;
+        let lastDotStr, indiNum, famNum, messages;
 
         rendering.innerHTML = '<div class="d-flex justify-content-center h-100"><div class="spinner-border align-self-center" role="status"><span class="sr-only">Loading...</span></div></div>';
         rendering.hidden = false;
 
-        var h = window.innerHeight - document.querySelector('.wt-header-wrapper').getBoundingClientRect().height - document.querySelector('.wt-footers').getBoundingClientRect().height;
+        const h = window.innerHeight - document.querySelector('.wt-header-wrapper').getBoundingClientRect().height - document.querySelector('.wt-footers').getBoundingClientRect().height;
         rendering.style.height = h + "px";
 
 
@@ -599,13 +599,13 @@ use Fisharebest\Webtrees\Tree;
             famNum = dotStr.substring(0,dotStr.indexOf("|"));
             dotStr = dotStr.substring(dotStr.indexOf("|")+1);
             lastDotStr = dotStr;
-            var images = [...lastDotStr.matchAll(/<IMG[^>]+SRC="([^"]*)/gmi)].map(function (matches) {
+            const images = [...lastDotStr.matchAll(/<IMG[^>]+SRC="([^"]*)/gmi)].map(function (matches) {
                 return {
                     path: matches[1],
                     width: '150px',
                     height: '150px'
                 };
-            })
+            });
             console.log("Starting render (found " + images.length + " images)");
             return viz.renderSVGElement(dotStr, {
                 images: images
@@ -613,7 +613,7 @@ use Fisharebest\Webtrees\Tree;
         }).then(function (element) {
             // Now we have to clean up the generated SVG.
 
-            // remove title tags so we don't get weird data on hover,
+            // remove title tags, so we don't get weird data on hover,
             // instead this defaults to the XREF of the record
             const a = element.getElementsByTagName("a");
             for (let i = 0; i < a.length; i++) {
@@ -623,12 +623,11 @@ use Fisharebest\Webtrees\Tree;
             element.innerHTML = element.innerHTML.replaceAll("%26", "&amp;");
             // Don't show anything when hovering on blank space
             element.innerHTML = element.innerHTML.replaceAll("<title>WT_Graph</title>", "");
-
             console.log("Appending SVG", element);
             // Clear current rendering then append new element to the page
             rendering.innerHTML = "";
             rendering.appendChild(element);
-            var fullZoom = Math.min(2, rendering.getBoundingClientRect().width / element.getBBox().width);
+            const fullZoom = Math.min(2, rendering.getBoundingClientRect().width / element.getBBox().width);
             panzoom(element, {
                 maxZoom: 2,
                 minZoom: fullZoom / 2,


### PR DESCRIPTION
This change fixes the viewBox when DPI too high
viewBox is set by Viz.js so we edit this after SVG generated, before appending element to the page
Also a fix for large toast messages not being centered.

Important note: the CANVAS element used for client side downloads has a maximum size, which varies by browser. I have added an error message when this is reached and causes the download to fail.

Resolves #138 