### PR TITLE
Remember output type

### DIFF
--- a/module.php
+++ b/module.php
@@ -275,7 +275,13 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
             return $this->showDOTFile($individual->tree(), $individual);
         } else {
             $temp_dir = $this->saveDOTFile($individual->tree(), $individual, $_REQUEST["vars"]["otype"] == 'svg' || $_REQUEST["vars"]["otype"] == 'dot');
-            return $this->downloadFile($temp_dir, $_REQUEST["vars"]["otype"]);
+            // If browser mode, output dot instead of selected file
+            if (isset($_POST["browser"]) && $_POST["browser"] == "true") {
+                $browser = true;
+            } else {
+                $browser = false;
+            }
+            return $this->downloadFile($temp_dir, $browser ? "dot" : $_REQUEST["vars"]["otype"]);
         }
     }
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -549,9 +549,7 @@ use Fisharebest\Webtrees\Tree;
     });
 
     function updateRender() {
-        const oldOtype = document.getElementById('vars[otype]').value;
-        document.getElementById('vars[otype]').value = 'dot';
-        // Set value to true so we can return other info with DOT file
+        // Set browser value to true so we can return other info with DOT file
         // that can't be included with downloaded file
         document.getElementById("browser").value = "true";
         // Enable disabled fields so they are included in serialised data - this means the values are remembered
@@ -566,8 +564,6 @@ use Fisharebest\Webtrees\Tree;
             toggleCart(true);
         }
         document.getElementById("browser").value = "false";
-
-        document.getElementById('vars[otype]').value = oldOtype;
         let lastDotStr, indiNum, famNum, messages;
 
         rendering.innerHTML = '<div class="d-flex justify-content-center h-100"><div class="spinner-border align-self-center" role="status"><span class="sr-only">Loading...</span></div></div>';


### PR DESCRIPTION
After generating the browser output, the output file type was always set to "dot" due to the output being changed to dot by javascript in order to have the dot string returned for displaying in the browser. This changes this so that the output type is not changed, and instead the backend will use "dot" as a value if the $browser variable is true but not change the form or save dot in the cookie.

Resolves #156 