### PR TITLE
Adjust checkbox alignment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,10 +8,10 @@ Version 2.1.10
 Version 2.1.9 (2022-08-30):
   - New         : Refreshed diagram design
   - New         : Advanced option to skip scanning tree for unseen relative links to speed up generation at the expense of accuracy
-  - Fixed       : Children with pedigree other than by birth no longer as non-related even when this option is disabled
+  - Fixed       : Children with pedigree other than by birth no longer show as non-related even when this option is disabled
   - Fixed       : Fix for endless loop in specific tree scenario when option to display non-relatives in a different colour is selected
   - Fixed       : Fix for page render not generating on page load when scripts load in unusual order (particularly, external script loads before internal script element)
-  - Fixed       : Fixed issue where some server setups would not load GVExport because of null country in sountry list
+  - Fixed       : Fixed issue where some server setups would not load GVExport because of null country in country list
 
 Version 2.1.8 (2022-08-21):
   - New         : Export to SVG, PNG, and JPG without needing GraphViz installed

--- a/resources/css/gvexport.css
+++ b/resources/css/gvexport.css
@@ -92,7 +92,7 @@
 
 .check-list {
     width: 90%;
-    vertical-align: middle;
+    vertical-align: top;
     margin-left: 10px;
 }
 


### PR DESCRIPTION
Top-aligned the checkboxes that go with the settings to enable of disable blood relatives being a different colour

Fixes #179 