### PR TITLE
When login expired, reload page

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -630,6 +630,12 @@ use Fisharebest\Webtrees\Tree;
             }
             return response.text();
         }).then(function (dotStr) {
+            // Check we actually got a DOT returned - sometimes webtrees gives an error
+            if (dotStr.indexOf("<!DOCTYPE html>") !== -1) {
+                showToast("E:<?= I18N::translate('Login expired. Reloading page...'); ?>");
+                setTimeout(function(){location.reload();}, 3000);
+                return false;
+            }
             // Grab our messages and individual and family record counts from
             // our return string - and remove them before passing the rest
             // of the string to DOT processor


### PR DESCRIPTION
If the session is no longer valid in webtrees (e.g. you logged out in another window or your login has timed out), then an error is shown as a toast message.

Closes #186