### PR TITLE
Fix combined mode

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1695,8 +1695,10 @@ class Dot {
 
 							// Work out if indi has adoptive relationship to this family
 							$relationshipType = $this->getRelationshipType($child, $fam, $ind);
-							if ($relationshipType != "") {
-                                $individuals[$child_id]["fams"][$fid]["reltype"] = $relationshipType;
+                            // Work out if WE have adoptive relationship to this family
+                            $sourceRelationshipType = $this->getRelationshipType($i, $fam, $ind);
+							if ($relationshipType != "" || $sourceRelationshipType != "") {
+                                if ($relationshipType != "") $individuals[$child_id]["fams"][$fid]["reltype"] = $relationshipType;
 								$related = false;
 							} else {
 								$related = $rel;

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -463,7 +463,7 @@ class Dot {
 		if (!functionsClippingsCart::isIndividualInCart($this->tree) || !$this->settings["usecart"] ) {
 			// Create our tree
 			$this->createIndiList($this->individuals, $this->families, false);
-			if ($this->settings["diagram_type"] == "combined") {
+			if ($this->settings["diagram_type"] == "combined" && $this->indi_search_method["spou"] != "") {
 				$this->removeGhosts($this->individuals, $this->families);
 			}
 			// If option to display related in another colour is selected,

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -662,12 +662,14 @@ use Fisharebest\Webtrees\Tree;
             // Grab our messages and individual and family record counts from
             // our return string - and remove them before passing the rest
             // of the string to DOT processor
-            messages = dotStr.substring(0,dotStr.indexOf("|"));
-            dotStr = dotStr.substring(dotStr.indexOf("|")+1);
-            indiNum = dotStr.substring(0,dotStr.indexOf("|"));
-            dotStr = dotStr.substring(dotStr.indexOf("|")+1);
-            famNum = dotStr.substring(0,dotStr.indexOf("|"));
-            dotStr = dotStr.substring(dotStr.indexOf("|")+1);
+            if (dotStr.indexOf("digraph WT_Graph {") !== -1) {
+                messages = dotStr.substring(0, dotStr.indexOf("|"));
+                dotStr = dotStr.substring(dotStr.indexOf("|") + 1);
+                indiNum = dotStr.substring(0, dotStr.indexOf("|"));
+                dotStr = dotStr.substring(dotStr.indexOf("|") + 1);
+                famNum = dotStr.substring(0, dotStr.indexOf("|"));
+                dotStr = dotStr.substring(dotStr.indexOf("|") + 1);
+            }
             lastDotStr = dotStr;
             const images = [...lastDotStr.matchAll(/<IMG[^>]+SRC="([^"]*)/gmi)].map(function (matches) {
                 return {


### PR DESCRIPTION
This pull request resolves #198, where records are no listed in combined mode if there are no spouse all children in the diagram. Disabling spouses should not cause all these records to disappear, it is due to a check that is intended to resolve issue #141 with a half-complete record being shown. But if spouses are unselected, then a family with one spouse is not half-complete. This resolves this issue. 

It also contains a fix for a situation where the blood-relationship status could be wrong if an adopted starting individual had adopted siblings who were blood related to the parents/family.