### PR TITLE
Fix selected indi being reset

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -333,17 +333,34 @@ function toggleAdvanced(caller, id) {
 }
 
 function setStateFastRelationCheck() {
-    if ((!cartempty && document.getElementById("vars[usecart]_yes").checked) || !document.getElementById("vars[marknr]").checked)
-    {
-        document.getElementById("vars[fastnr]").disabled = true;
-    } else {
-        document.getElementById("vars[fastnr]").disabled = false;
+    document.getElementById("vars[fastnr]").disabled = ((!cartempty && document.getElementById("vars[usecart]_yes").checked) || !document.getElementById("vars[marknr]").checked);
+}
+
+function removeURLParameter(parameter) {
+    updateURLParameter(parameter, "", true);
+}
+
+function updateURLParameter(parameter, value, remove) {
+    let url=document.location.href.split("?")[0];
+    let args=document.location.href.split("?")[1];
+    let params = new URLSearchParams(args);
+    if (params.toString().search(parameter) !== -1) {
+        if (remove) {
+            params.delete(parameter);
+        } else {
+            params.set(parameter, value);
+        }
+        history.pushState(null, '', url + "?" + params.toString());
     }
 }
 
-function runAutoUpdate(on) {
-    if (on) {
-        updateRender();
+function formChanged(autoUpdate) {
+    let xref = document.getElementById('pid').value.trim();
+    if (xref !== "") {
+        if (autoUpdate) {
+            updateRender();
+        }
+        updateURLParameter("xref",xref);
     }
 }
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -62,7 +62,7 @@ use Fisharebest\Webtrees\Tree;
     <?= $title ?>
 </h2>
 
-<form action="<?= $module->chartUrl($individual) ?>" method="post" class="wt-page-options sidebar d-print-none" id="gvexport" onchange="runAutoUpdate(autoUpdate)">
+<form action="<?= $module->chartUrl($individual) ?>" method="post" class="wt-page-options sidebar d-print-none" id="gvexport" onchange="formChanged(autoUpdate)">
 
     <div class="pull-right btn-hover">
         <a href="#" class="hide-form btn btn-secondary">X</a>
@@ -567,13 +567,7 @@ use Fisharebest\Webtrees\Tree;
 
         // Remove reset parameter from URL when page loaded, to prevent
         // further resets when page reloaded
-        let url=document.location.href.split("?")[0];
-        let args=document.location.href.split("?")[1];
-        let params = new URLSearchParams(args);
-        if (params.toString().search("reset") !== -1) {
-            params.delete('reset');
-            history.pushState(null, '', url + "?" + params.toString())
-        }
+        removeURLParameter("reset");
     }
 
     // Trigger action when "Update" button clicked


### PR DESCRIPTION
If you change the starting individual, then refresh the page, they are reset to the original because the XREF is in the URL. This commit updates the URL with the new indi XREF so a refresh will remember the same indi.

Resolves #207