### PR TITLE
Resolve issue with related setting

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -1698,12 +1698,7 @@ class Dot {
 							//var_dump($fams);
 						}
 						// -------------
-
-						if ($this->settings["mark_not_related"] == TRUE) {
-							$this->addIndiToList($pid."|Code 6", $spouse_id, $this->indi_search_method["any"] && $ance, $this->indi_search_method["any"] && $desc, $this->indi_search_method["any"], $this->indi_search_method["any"], FALSE, $ind, $level, $individuals, $families, $full);
-						} else {
-							$this->addIndiToList($pid."|Code 7", $spouse_id, $this->indi_search_method["any"], $this->indi_search_method["any"] && $level > -1*$desc_level, $this->indi_search_method["any"], $this->indi_search_method["any"], TRUE, $ind, $level, $individuals, $families, $full);
-						}
+                        $this->addIndiToList($pid."|Code 6", $spouse_id, $this->indi_search_method["any"] && $ance, $this->indi_search_method["any"] && $desc, $this->indi_search_method["any"], $this->indi_search_method["any"], FALSE, $ind, $level, $individuals, $families, $full);
 					}
 
 				}


### PR DESCRIPTION
If related individuals option was selected, sometimes different indis would be shown than when it wasn't selected. This change updates the code to ensure the same indis are shown (going with what is displayed when the option is enabled)