### PR TITLE
Abbreviate secondary name

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -986,9 +986,11 @@ class Dot {
             $names = $i->getAllNames();
             $nameArray = $names[$i->getPrimaryName()];
             $name = $this->getFormattedName($nameArray, $pid);
-            if ($this->settings["use_abbr_name"] !== "70") { /* don't show names setting */
-                $addname = $this->getFormattedName([$i->alternateName()], "");//@@ Meliza Amity
-                if (!empty($addname)) {
+
+            if ($i->getPrimaryName() !== $i->getSecondaryName()) {
+                $altNameArray = $names[$i->getSecondaryName()];
+                $addname = $this->getFormattedName($altNameArray, "");
+                if (!empty($addname) && trim($addname) !== "" && $this->settings["use_abbr_name"] < 50) {
                     if ($this->settings["diagram_type"] == "simple")
                         $name .= '\n' . $addname;//@@ Meliza Amity
                     else


### PR DESCRIPTION
If individual has secondary name (name in another script), then abbreviate this as well. If option for initials is shown, do not show alternate name at all as this isn't working properly.

Related to #212 