### PR TITLE
Remove MCLIMIT

### DIFF
--- a/config.php
+++ b/config.php
@@ -139,7 +139,7 @@ $GVE_CONFIG["default_typeface"] = 0;
 $GVE_CONFIG["settings"]["typefaces"] = [0 => "Arial", 10 => "Brush Script MT" ,  20 => "Courier New", 30 => "Garamond", 40 => "Georgia", 50 => "Tahoma", 60 => "Times New Roman", 70 => "Trebuchet MS", 80 => "Verdana"];
 
 // mclimit settings (number of iterations to help to reduce crossings)
-$GVE_CONFIG["default_mclimit"] = "50";
+$GVE_CONFIG["default_mclimit"] = "1";
 $GVE_CONFIG["mclimits"] = ["1" => "1", "5" => "5" , "20" => "20", "50" => "50", "100" => "100"];
 
 // Customization

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -404,14 +404,6 @@ use Fisharebest\Webtrees\Tree;
             </div>
 
             <div class="row form-group">
-                <label class=" col-sm-4 col-form-label wt-page-options-label" for="vars[grdir]"><?= I18N::translate('Number of iterations (MCLIMIT)') ?></label>
-                <div class="col-sm-8 wt-page-options-value">
-                    <?= view('components/select', ['name' => 'vars[mclimit]', 'selected' => $vars['mclimit'], 'options' => $gve_config["mclimits"]]) ?>
-                    <small class="form-text text-muted"><?= I18N::translate('helps to reduce the crossings on the graph. This can be really slow (up to 10..15x compared to the 20 setting)') ?></small>
-                </div>
-            </div>
-
-            <div class="row form-group">
                 <label class=" col-sm-4 col-form-label wt-page-options-label" for="vars[dpi]"><?= I18N::translate('DPI') ?></label>
                 <div class="col-sm-8 wt-page-options-value">
                     <div class="row">


### PR DESCRIPTION
Remove MCLIMIT setting from UI. This setting appears to do nothing, at least in the context of GVExport. Retained in config.php in case it is needed by users. Default now 1 instead of 50.

Resolves #163 