### PR TITLE
Add fallback fonts of same generic family

### DIFF
--- a/config.php
+++ b/config.php
@@ -136,7 +136,8 @@ $GVE_CONFIG["directions"]["LR"] = "Left-to-Right";
 
 // Font name
 $GVE_CONFIG["default_typeface"] = 0;
-$GVE_CONFIG["settings"]["typefaces"] = [0 => "Arial", 10 => "Brush Script MT" ,  20 => "Courier New", 30 => "Garamond", 40 => "Georgia", 50 => "Tahoma", 60 => "Times New Roman", 70 => "Trebuchet MS", 80 => "Verdana"];
+$GVE_CONFIG["settings"]["typefaces"] =         [0 => "Arial", 10 => "Brush Script MT" ,  20 => "Courier New", 30 => "Garamond", 40 => "Georgia", 50 => "Tahoma", 60 => "Times New Roman", 70 => "Trebuchet MS", 80 => "Verdana"];
+$GVE_CONFIG["settings"]["typeface_fallback"] = [0 => "Sans",  10 => "Cursive" ,          20 => "Monospace",   30 => "Serif",    40 => "Serif",   50 => "Sans",   60 => "Serif",           70 => "Sans",         80 => "Sans"];
 
 // mclimit settings (number of iterations to help to reduce crossings)
 $GVE_CONFIG["default_mclimit"] = "1";

--- a/functions_dot.php
+++ b/functions_dot.php
@@ -74,6 +74,7 @@ class Dot {
 		$this->settings["defaulttypeface"] = $GVE_CONFIG["default_typeface"];
 		$this->settings["typeface"] = $this->settings["defaulttypeface"];
         $this->settings["typefaces"] = $GVE_CONFIG["settings"]["typefaces"];
+        $this->settings["typeface_fallback"] = $GVE_CONFIG["settings"]["typeface_fallback"];
 
 		// Load colors
 		$this->colors["colorm"] = $GVE_CONFIG["dot"]["colorm"];
@@ -819,7 +820,7 @@ class Dot {
 		if ($this->settings["diagram_type"] == "simple") {
 			$out .= "node [ shape=box, style=filled fontsize=\"" . $this->font_size ."\" fontname=\"" . $this->settings["typeface"] ."\"];\n";
 		} else {
-			$out .= "node [ shape=plaintext fontsize=\"" . $this->font_size ."\" fontname=\"" . $this->settings["typefaces"][$this->settings["typeface"]] .", " . $this->settings["typefaces"][$this->settings["defaulttypeface"]] . ", Sans\"];\n";
+			$out .= "node [ shape=plaintext fontsize=\"" . $this->font_size ."\" fontname=\"" . $this->settings["typefaces"][$this->settings["typeface"]] . ", " . $this->settings["typeface_fallback"][$this->settings["typeface"]] .", " . $this->settings["typefaces"][$this->settings["defaulttypeface"]] . ", Sans\"];\n";
 		}
 		return $out;
 	}


### PR DESCRIPTION
If font not found, instead of defaulting straight back to default font (Arial), instead try generic family. For example, if Times New Roman not found, default to Serif. This should work better on mobile where standard websafe fonts are not available.

Closes #219 