### PR TITLE
Change descendants

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -471,6 +471,12 @@ function removeItem(element) {
     const regex = new RegExp(`(?<=,|^)(${xref})(?=,|$)`);
     list.value = list.value.replaceAll(" ","").replace(regex, "");
     list.value = list.value.replace(",,", ",");
+    if (list.value.substring(0,1) === ",") {
+        list.value = list.value.substring(1);
+    }
+    if (list.value.substring(list.value.length-1) === ",") {
+        list.value = list.value.substring(0, list.value.length-1);
+    }
     element.remove();
     changeURLXref(list.value.split(",")[0].trim());
     updateClearAll();

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -571,8 +571,8 @@ use Fisharebest\Webtrees\Tree;
 
     function pageLoaded() {
         TOMSELECT_URL = document.getElementById('pid').getAttribute("data-url") + "&query=";
-        loadXrefList(TOMSELECT_URL);
         loadURLXref();
+        loadXrefList(TOMSELECT_URL);
         // Remove reset parameter from URL when page loaded, to prevent
         // further resets when page reloaded
         removeURLParameter("reset");


### PR DESCRIPTION
Treat descent level 0 and disabled descendants the same.
Add spouses to youngest generation (when enabled)
Family records with no children and only one partner are no longer shown in Decorated and Simple mode.

Resolves #201

Also a small change to the starting individual selection to resolve a bug with the XREF listed in the URL being added again on page refresh when it had previously been removed.