### PR TITLE
Add X for closing fullscreen

### DIFF
--- a/functions_dot.php
+++ b/functions_dot.php
@@ -962,7 +962,7 @@ class Dot {
 			if ($isdead) {
 				$deathplace = $this->convertToHTMLSC($deathplace);
 			}
-            $href = $this->settings["show_url"] ? " HREF=\"" . $this->convertToHTMLSC($link) . "\"" : "";
+            $href = $this->settings["show_url"] ? "TARGET=\"_blank\" HREF=\"" . $this->convertToHTMLSC($link) . "\"" : "";
 			// Draw table
 			if ($this->settings["diagram_type"] == "combined") {
 				$out .= "<TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLPADDING=\"2\" CELLSPACING=\"0\" BGCOLOR=\"" . $this->colors["colorindibg"] . "\" $href>";
@@ -1138,7 +1138,7 @@ class Dot {
 		} else {
 		// Non-combined type
 			if ($this->settings["show_url"]) {
-                $href = "href=\"" . $this->convertToHTMLSC($link) . "\", target=\"_blank\", ";
+                $href = "target=\"_blank\" href=\"" . $this->convertToHTMLSC($link) . "\", target=\"_blank\", ";
             } else {
                 $href = "";
             }

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -529,8 +529,7 @@ function updateClearAll() {
 // Toggle full screen for element
 // Modified from https://stackoverflow.com/questions/7130397/how-do-i-make-a-div-full-screen
 function toggleFullscreen() {
-// if already full screen; exit
-// else go fullscreen
+    // If already fullscreen, exit fullscreen
     if (
         document.fullscreenElement ||
         document.webkitFullscreenElement ||
@@ -546,7 +545,7 @@ function toggleFullscreen() {
         } else if (document.msExitFullscreen) {
             document.msExitFullscreen();
         }
-    } else {
+    } else { // Not full screen, so go fullscreen
         const element = document.getElementById('render-container');
         if (element.requestFullscreen) {
             element.requestFullscreen();
@@ -558,4 +557,31 @@ function toggleFullscreen() {
             element.msRequestFullscreen();
         }
     }
+}
+
+function handleFullscreen() {
+    if (document.addEventListener)
+    {
+        document.addEventListener('fullscreenchange', handleFullscreenExit, false);
+        document.addEventListener('mozfullscreenchange', handleFullscreenExit, false);
+        document.addEventListener('MSFullscreenChange', handleFullscreenExit, false);
+        document.addEventListener('webkitfullscreenchange', handleFullscreenExit, false);
+    }
+}
+
+function handleFullscreenExit()
+{
+    if (!document.webkitIsFullScreen && !document.mozFullScreen && !document.msFullscreenElement)
+    {
+        showHide(document.getElementById("fullscreenButton"), true);
+        showHide(document.getElementById("fullscreenClose"), false);
+    } else {
+        showHide(document.getElementById("fullscreenButton"), false);
+        showHide(document.getElementById("fullscreenClose"), true);
+    }
+}
+
+function getComputedProperty(element, property) {
+    const style = getComputedStyle(element);
+    return (parseFloat(style.getPropertyValue(property)));
 }

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -550,7 +550,8 @@ use Fisharebest\Webtrees\Tree;
 
 <div id="render-container">
     <div id="rendering" hidden style="border: 1px solid black; overflow: hidden; background-color: <?= $vars["colorbg"] ?>;"></div>
-    <a href="#" title="<?= I18N::translate('Fullscreen') ?>" onclick="toggleFullscreen()" class="fullscreen">⛶</a>
+    <a href="#" title="<?= I18N::translate('Fullscreen') ?>" onclick="toggleFullscreen()" class="fullscreen" id="fullscreenButton">⛶</a>
+    <a href="#" title="<?= I18N::translate('Fullscreen') ?>" onclick="toggleFullscreen()" class="fullscreen" id="fullscreenClose" style="display: none;">✖</a>
 </div>
 
 <script type="text/javascript">
@@ -573,6 +574,8 @@ use Fisharebest\Webtrees\Tree;
         removeURLParameter("reset");
         // Remove options from selection list if already selected
         setInterval(function () {removeSelectedOptions()}, 100);
+        // Listen for fullscreen change
+        handleFullscreen();
         // Load browser render when page has loaded
         updateRender();
     }
@@ -649,11 +652,15 @@ use Fisharebest\Webtrees\Tree;
         const MARGIN = 50;
         const h = window.innerHeight - document.querySelector('.wt-header-wrapper').getBoundingClientRect().height - document.querySelector('.wt-footers').getBoundingClientRect().height;
         const w = window.innerWidth - MARGIN*2;
-
+        const wtMainContainer = document.getElementsByClassName('wt-main-container').item(0);
+        const wtTitle = document.getElementsByClassName("wt-page-title").item(0);
+        // Set size of render element to fit browser
         document.getElementById('render-container').style.height = h + "px";
         document.getElementById('render-container').style.width = w + "px";
         document.getElementById('render-container').style.left = MARGIN + "px";
-
+        // Set size of container element so webtrees footer is in the right place
+        const totalHeight = MARGIN + wtTitle.getBoundingClientRect().height + getComputedProperty(wtTitle, 'margin-bottom') + h + getComputedProperty(wtMainContainer, 'padding-top');
+        wtMainContainer.style.height = totalHeight + "px";
 
         window.fetch(form.getAttribute('action'), {
             method: form.getAttribute('method'),


### PR DESCRIPTION
Instead of having the same icon, now an X shows to close fullscreen mode.

Also contains two minor changes:
 - Fix for webtrees footer being partially covered
- Fix for links not opening in new tab in some cases

Related to #234 