### PR TITLE
Fix links on mobile

### DIFF
--- a/resources/css/gvexport.css
+++ b/resources/css/gvexport.css
@@ -102,6 +102,9 @@
     width: 100%;
     height: 100%;
     margin: 0;
+    touch-action: none;
+    border: 1px solid black;
+    overflow: hidden;
 }
 
 .picker-label {

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -13,9 +13,9 @@ use Fisharebest\Webtrees\Tree;
 
 /**
  * @var string      $gvexport_css           used in javascript code as a link to the css file
+ * @var string      $gvexport_js            used in javascript code as a link to the external script file
  * @var Tree        $tree                   used tree
- * @var Individual  $individual             ?
-// unused parameter $disposition
+ * @var Individual  $individual             The webtrees individual object of the XREF in the URL
  * @var string      $title                  title of this page
  * @var array       $vars                   array of saved settings
  * @var array       $otypes                 output file type options
@@ -556,7 +556,7 @@ use Fisharebest\Webtrees\Tree;
 </div>
 
 <div id="render-container">
-    <div id="rendering" hidden style="border: 1px solid black; overflow: hidden; background-color: <?= $vars["colorbg"] ?>;"></div>
+    <div id="rendering" hidden style="background-color: <?= $vars["colorbg"] ?>;"></div>
     <a href="#" title="<?= I18N::translate('Fullscreen') ?>" onclick="toggleFullscreen()" class="fullscreen" id="fullscreenButton">⛶</a>
     <a href="#" title="<?= I18N::translate('Exit fullscreen') ?>" onclick="toggleFullscreen()" class="fullscreen" id="fullscreenClose" style="display: none;">✖</a>
 </div>
@@ -752,7 +752,11 @@ use Fisharebest\Webtrees\Tree;
             panzoomInst = panzoom(element, {
                 maxZoom: 4,
                 minZoom: fullZoom / 4,
-                initialZoom: fullZoom
+                initialZoom: fullZoom,
+                onTouch: function(e) {
+                    // Fix links not working on mobile
+                    return false; // tells the library to not preventDefault.
+                }
             });
             showToast(`<?= I18N::translate('Generated ${indiNum} individuals and ${famNum} family records'); ?>`, 5000);
             if (messages !== "") {


### PR DESCRIPTION
Panzoom library prevents touch actions by default. We disable this, but then need to add CSS to stop weird stuff happening (specifically: touch-action: none added to stop page scrolling when render is dragged).

Resolves #249 