### PR TITLE
Don't click if dragging

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -641,3 +641,57 @@ function scrollToRecord(xref) {
     }
     return false;
 }
+
+// Return distance between two points
+function getDistance(x1, y1, x2, y2){
+    let x = x2 - x1;
+    let y = y2 - y1;
+    return Math.sqrt(x * x + y * y);
+}
+
+function handleTileClick() {
+    const MIN_DRAG = 100;
+    let startx;
+    let starty;
+
+    let linkElements = document.querySelectorAll("svg a");
+    for (let i = 0; i < linkElements.length; i++) {
+        linkElements[i].addEventListener("mousedown", function(e) {
+            startx = e.clientX;
+            starty = e.clientY;
+        });
+        // Only trigger links if not dragging
+        linkElements[i].addEventListener("click", function(e) {
+            if (getDistance(startx, starty, e.clientX, e.clientY) >= MIN_DRAG) {
+                e.preventDefault();
+            }
+        });
+    }
+}
+
+// This function is run when the page is loaded
+function pageLoaded() {
+    jsPDF = window.jspdf.jsPDF;
+    TOMSELECT_URL = document.getElementById('pid').getAttribute("data-url") + "&query=";
+    loadURLXref();
+    loadXrefList(TOMSELECT_URL);
+    // Remove reset parameter from URL when page loaded, to prevent
+    // further resets when page reloaded
+    removeURLParameter("reset");
+    // Remove options from selection list if already selected
+    setInterval(function () {removeSelectedOptions()}, 100);
+    // Listen for fullscreen change
+    handleFullscreen();
+    // Load browser render when page has loaded
+    updateRender();
+
+    document.querySelector(".hide-form").addEventListener("click", hideSidebar);
+
+    document.querySelector(".sidebar__toggler a").addEventListener("click", showSidebar);
+
+    document.addEventListener("keydown", function(e) {
+        if (e.key === "Esc" || e.key === "Escape") {
+            document.querySelector(".sidebar").hidden ? showSidebar(e) : hideSidebar(e);
+        }
+    });
+}

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -575,32 +575,7 @@ use Fisharebest\Webtrees\Tree;
     var form = document.getElementById('gvexport');
     var rendering = document.getElementById('rendering');
 
-    function pageLoaded() {
-        jsPDF = window.jspdf.jsPDF;
-        TOMSELECT_URL = document.getElementById('pid').getAttribute("data-url") + "&query=";
-        loadURLXref();
-        loadXrefList(TOMSELECT_URL);
-        // Remove reset parameter from URL when page loaded, to prevent
-        // further resets when page reloaded
-        removeURLParameter("reset");
-        // Remove options from selection list if already selected
-        setInterval(function () {removeSelectedOptions()}, 100);
-        // Listen for fullscreen change
-        handleFullscreen();
-        // Load browser render when page has loaded
-        updateRender();
 
-        document.querySelector(".hide-form").addEventListener("click", hideSidebar);
-
-
-        document.querySelector(".sidebar__toggler a").addEventListener("click", showSidebar);
-
-        document.addEventListener("keydown", function(e) {
-            if (e.key === "Esc" || e.key === "Escape") {
-                document.querySelector(".sidebar").hidden ? showSidebar(e) : hideSidebar(e);
-            }
-        });
-    }
 
     // Trigger action when "Update" button clicked
     document.querySelector('.update-browser-rendering').addEventListener('click', function(e) {
@@ -769,6 +744,7 @@ use Fisharebest\Webtrees\Tree;
             }
             // Scroll render to first starting individual
             scrollToRecord(document.getElementById('vars[other_pids]').value.split(",")[0].trim());
+            handleTileClick();
 
             return element;
         }).catch(function (error) {


### PR DESCRIPTION
When dragging the browser rendering, if we start dragging on a tile then when we stop dragging a new window is opened with the record as if we had clicked on it. This change means we don't trigger the click if dragged more than the minimum distance (currently 100 pixels)

Resolves #253 