### PR TITLE
Tweak text based on if graphviz installed

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -292,7 +292,7 @@ use Fisharebest\Webtrees\Tree;
                 <div class="col-sm-8 wt-page-options-value">
                     <input type="hidden" name="vars[show_url]" value="no">
                     <input type="checkbox" name="vars[show_url]" id="vars[show_url]" value="show_url" <?= $vars["show_url"] == "show_url" ? 'checked' : '' ?>>
-                    <span class="text-muted">(<?= I18N::translate('SVG only') ?>)</span>
+                    <span class="text-muted">(<?= $nographviz ? I18N::translate('browser and SVG only') : I18N::translate('browser, SVG, and PDF only'); ?>)</span>
                 </div>
             </div>
 


### PR DESCRIPTION
If graphviz installed, note that browser, svg, and pdf all support URLs. If graphviz not installed, note just browser and svg as  client-side pdf does not support links.

Closes #260 