### PR TITLE
Fix issue with jsPDF

### DIFF
--- a/app/ImageFile.php
+++ b/app/ImageFile.php
@@ -38,7 +38,7 @@ class ImageFile
             $image = $this->loadImage($full_media_path);
             if ($image) {
                 $img_resized = imagescale($image, $this->dpi, -1);
-                if ($this->saveImage($img_resized, $temp_image_file)) {
+                if ($this->saveImage($img_resized, $temp_image_file, $full_media_path)) {
                     return $temp_dir . "/" . $filename;
                 } else {
                     // Resize failed for some reason, despite being supported format
@@ -90,9 +90,10 @@ class ImageFile
      *
      * @param $image
      * @param $temp_image_file_path
+     * @param $full_media_path
      * @return bool
      */
-    private function saveImage($image, $temp_image_file_path): bool
+    private function saveImage($image, $temp_image_file_path, $full_media_path): bool
     {
         $dir = dirname($temp_image_file_path);
 
@@ -101,6 +102,10 @@ class ImageFile
         $webtrees_dir = explode("webtrees",Site::getPreference('INDEX_DIRECTORY'))[0] . "webtrees";
         if (substr($temp_image_file_path, 0, strlen($webtrees_dir)) == $webtrees_dir) {
             die("Error: Temp directory cannot be within webtrees directory");
+        }
+        // Also check our temp file path is not the same as our media path
+        if (realpath($temp_image_file_path) == realpath($full_media_path)) {
+            die("Error: Temp file path cannot be the same as the media path");
         }
 
         if (!is_dir($dir)) {

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -628,7 +628,7 @@ function createPdfFromImage(imgData, width, height) {
     const dpi = document.getElementById('vars[dpi]').value;
     const widthInches = width/dpi;
     const heightInches = height/dpi;
-    const doc = new jsPDF({orientation: orientation, format: [widthInches, heightInches], unit: 'in'});
+    const doc = new window.jspdf.jsPDF({orientation: orientation, format: [widthInches, heightInches], unit: 'in'});
     doc.addImage(imgData, "PNG", 0, 0, widthInches, heightInches);
     doc.save("gvexport.pdf");
 }
@@ -711,7 +711,6 @@ function handleTileClick() {
 
 // This function is run when the page is loaded
 function pageLoaded() {
-    jsPDFInst = window.jspdf.jsPDF;
     TOMSELECT_URL = document.getElementById('pid').getAttribute("data-url") + "&query=";
     loadURLXref();
     loadXrefList(TOMSELECT_URL, 'vars[other_pids]', 'indi_list');

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -267,7 +267,7 @@ use Fisharebest\Webtrees\Tree;
                         <label for="vars[diagtype]_simple"><?= I18N::translate('Simple') ?></label>
                     </div>
                     <div class="col-auto">
-                        <input type="radio" onclick="togglePhotos(true)" name="vars[diagtype]" id="vars[diagtype]_decorated" value="decorated" <?= $vars["diagtype"] == "decorated" ? 'checked' : '' ?>>
+                        <input type="radio" onclick="togglePhotos(true)" name="vars[diagtype]" id="vars[diagtype]_decorated" value="decorated" data-cy="diagram_type_decorated" <?= $vars["diagtype"] == "decorated" ? 'checked' : '' ?>>
                         <label for="vars[diagtype]_decorated"><?= I18N::translate('Decorated') ?></label>
                     </div>
                     <div class="col-auto">
@@ -285,7 +285,7 @@ use Fisharebest\Webtrees\Tree;
                     <label class="col-sm-4 col-form-label wt-page-options-label" for="vars[with_photos]"><?= I18N::translate('Add photos') ?></label>
                     <div class="col-sm-8 wt-page-options-value">
                         <input type="hidden" name="vars[with_photos]" value="no">
-                        <input type="checkbox" name="vars[with_photos]" id="vars[with_photos]" value="with_photos" <?= $vars["with_photos"] == "with_photos" ? 'checked' : '' ?>>
+                        <input type="checkbox" name="vars[with_photos]" id="vars[with_photos]" value="with_photos" data-cy="with_photos" <?= $vars["with_photos"] == "with_photos" ? 'checked' : '' ?>>
                         <span class="text-muted">(<?= I18N::translate('Only Decorated or Combined') ?>)</span>
                     </div>
                 </div>
@@ -536,7 +536,7 @@ use Fisharebest\Webtrees\Tree;
                 </div>
             </div>
         </div>
-        <a href="#" onclick="toggleAdvanced(this, 'appearance-advanced')"><div class="wt-page-options-label advanced-settings-btn"><?= ($vars["adv_appear"] == "show" ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["adv_appear"] == "show" ? ' ↑' : ' ↓'); ?></div></a>
+        <a href="#" onclick="toggleAdvanced(this, 'appearance-advanced')"><div class="wt-page-options-label advanced-settings-btn" data-cy="appearance-advanced"><?= ($vars["adv_appear"] == "show" ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["adv_appear"] == "show" ? ' ↑' : ' ↓'); ?></div></a>
         <h3><?= /* I18N: Appearance heading */ I18N::translate('Output settings') ?></h3>
         <div class="row form-group">
             <?= addLabelWithHelp('vars[otype]', 'Output file type'); ?>
@@ -579,7 +579,6 @@ use Fisharebest\Webtrees\Tree;
 <script type="text/javascript">
     const graphvizAvailable = <?= $nographviz ? "false" : "true" ?>;
     let panzoomInst = null;
-    let jsPDFInst = null;
     const workerURL = '<?= $module->assetUrl('javascript/full.renderer.js'); ?>';
     let viz = new Viz({
         workerURL: workerURL


### PR DESCRIPTION
Resolves #280 where PDF (and sometimes other files) could not be downloaded if GraphViz not installed on server. 

Also includes an additional check to protect original media files when resizing, and some additions to help with automated frontend testing. 