### PR TITLE
Scroll to last person on list not first

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -753,8 +753,15 @@ use Fisharebest\Webtrees\Tree;
                     showToast(message[i]);
                 }
             }
-            // Scroll render to first starting individual
-            scrollToRecord(document.getElementById('vars[other_pids]').value.split(",")[0].trim());
+            // Scroll render to last starting individual
+            let indiList = document.getElementById('vars[other_pids]').value.split(",");
+            for (let i = indiList.length-1; i>=0; i--) {
+                if (indiList[i].trim() !== "") {
+                    scrollToRecord(indiList[i].trim());
+                    break;
+                }
+            }
+
             handleTileClick();
 
             return element;


### PR DESCRIPTION
When loading the diagram, scroll to the last XREF on the list so when a new starting person is added, it will scroll to them.

Closes #285