### PR TITLE
Fix show xref

### DIFF
--- a/app/Dot.php
+++ b/app/Dot.php
@@ -574,7 +574,7 @@ class Dot {
 		$out .= " [ ";
 
 		// Showing the ID of the family, if set
-		if ($this->settings["show_fid"]) {
+		if ($this->settings["show_fid"] == "show_fid") {
 			$family = " (" . $fid . ")";
 		} else {
 			$family = "";

--- a/app/Person.php
+++ b/app/Person.php
@@ -264,7 +264,7 @@ class Person
 
         // If PID already in name (from another module), remove it, so we don't add twice
         $name = str_replace(" (" . $pid . ")", "", $name);
-        if ($this->dot->settings["show_pid"]) {
+        if ($this->dot->settings["show_pid"] == "show_pid") {
             // Show INDI id
             $name = $name . " (" . $pid . ")";
         }


### PR DESCRIPTION
XREFs were always shown regardless of setting after recent refactor, this is now fixed.

This is a symptom of a structure issue but for now I've just done a quick fix.