### PR TITLE
Default to XREF if no XREF provided

### DIFF
--- a/module.php
+++ b/module.php
@@ -42,6 +42,7 @@ spl_autoload_register(function ($class) {
 
 use Cassandra\Set;
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Localization\Translation;
@@ -158,8 +159,12 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
     {
         $tree = $request->getAttribute('tree');
         assert($tree instanceof Tree);
-
-        $individual = $this->getIndividual($tree, $request->getQueryParams()['xref']);
+        if (isset($request->getQueryParams()['xref'])) {
+            $xref = $request->getQueryParams()['xref'];
+        } else {
+            $xref = $tree->getUserPreference(Auth::user(), UserInterface::PREF_TREE_ACCOUNT_XREF);
+        }
+        $individual = $this->getIndividual($tree, $tree->significantIndividual(Auth::user(), $xref)->xref());
 		$userDefaultVars = (new Settings($this))->getSettings();
         if (!isset($_REQUEST['reset'])) {
             $cookie = new Cookie($tree);

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -348,19 +348,25 @@ function changeURLXref(xref) {
     }
 }
 function updateURLParameter(parameter, value, action) {
-    let url=document.location.href.split("?")[0];
-    let args=document.location.href.split("?")[1];
-    let params = new URLSearchParams(args);
-    if (params.toString().search(parameter) !== -1) {
-        if (action === "remove") {
-            params.delete(parameter);
-        } else if (action === "update") {
-            params.set(parameter, value);
-        } else {
-            return params.get(parameter);
+    let split = document.location.href.split("?");
+    let url = split[0];
+    if (split.length > 1) {
+        let args = split[1];
+        let params = new URLSearchParams(args);
+        if (params.toString().search(parameter) !== -1) {
+            if (action === "remove") {
+                params.delete(parameter);
+            } else if (action === "update") {
+                params.set(parameter, value);
+            } else {
+                return params.get(parameter);
+            }
         }
         history.pushState(null, '', url + "?" + params.toString());
+    } else if (action === "update") {
+        history.pushState(null, '', url + "?" +  parameter + "=" + value);
     }
+    return "";
 }
 
 function getURLParameter(parameter) {

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -2,8 +2,11 @@
 
 namespace vendor\WebtreesModules\gvexport;
 
+use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Tree;
 
 
@@ -25,6 +28,7 @@ use Fisharebest\Webtrees\Tree;
 
 $settings = (new Settings($module))->getSettings();
 $nographviz = $settings['graphviz_bin'] == "";
+$xref = $individual->xref();
 ?>
 
 <script type="text/javascript">
@@ -37,6 +41,7 @@ $nographviz = $settings['graphviz_bin'] == "";
 
     function runPageLoaded() {
         if (typeof pageLoaded === 'function' && typeof jQuery === 'function') {
+            changeURLXref('<?= $xref; ?>');
             pageLoaded();
         } else {
             // If external script loads before inline script, then wait
@@ -55,7 +60,6 @@ $nographviz = $settings['graphviz_bin'] == "";
     newScript.setAttribute("type","text/javascript");
     newScript.setAttribute("src","<?= $gvexport_js ?>");
     document.head.appendChild(newScript);
-
 </script>
 <script src="<?= $module->assetUrl('javascript/viz.js'); ?>"></script>
 <script src="<?= $module->assetUrl('javascript/panzoom.min.js'); ?>"></script>
@@ -92,9 +96,8 @@ $nographviz = $settings['graphviz_bin'] == "";
         /* Check if another module (e.g. vesta classic) is adding the XREF to
            the name. If so, we want to enable the XREF option for individuals
            unless we already have a saved setting */
-        $individual = $module->getIndividual($tree, $_GET["xref"]);
         $startName = $individual->fullName();
-        $name = str_replace(" (" . $_GET["xref"] . ")", "", $startName);
+        $name = str_replace(" (" . $xref . ")", "", $startName);
         if ($startName != $name && $vars["show_pid"] == "DEFAULT") {
             $overridePID = true;
         } else {


### PR DESCRIPTION
Instead of assuming it never happens, now we default to an XREF if none is provided. This is in the following order: First, prefer XREF in URL

Next, prefer XREF of user, if user is linked to an individual 

Last. let webtrees pick, using "significantIndividual" check.