### PR TITLE
Don't use cookies for logged in user

### DIFF
--- a/app/Cookie.php
+++ b/app/Cookie.php
@@ -2,31 +2,34 @@
 
 namespace vendor\WebtreesModules\gvexport;
 
+use Fisharebest\Webtrees\Tree;
+
 /**
  * A cookie object for saving settings
  */
 class Cookie
 {
     private string $name;
+    private Tree $tree;
 
     /**
      * Name for the cookie is generated based on tree name
      * @param $tree
      */
     function __construct($tree) {
-        $this->name = $this->getName($tree);
+        $this->tree = $tree;
+        $this->name = $this->getName();
     }
 
     /**
      * Return the name of the cookie
      *
-     * @param $tree
      * @return string
      */
-    private function getName($tree): string
+    private function getName(): string
     {
         // Get name of tree from webtrees
-        $name = $tree->name();
+        $name = $this->tree->name();
         // Replace space with underscore
         $name =  preg_replace('/\s/', '_', $name);
         // alphanumeric / underscore characters only

--- a/app/Dot.php
+++ b/app/Dot.php
@@ -62,7 +62,7 @@ class Dot {
 		$this->tree = $tree;
 		$this->file_system = $file_system;
     // Load settings from config file
-        $this->settings=(new Settings($module))->getSettings();
+        $this->settings=(new Settings())->getAdminSettings($module);
         $this->settings["no_fams"] = FALSE;
 	}
 

--- a/app/OutputFile.php
+++ b/app/OutputFile.php
@@ -17,7 +17,7 @@ class OutputFile
     var array $settings;
 
     function __construct($temp_dir, $file_type, $module) {
-        $this->settings = (new Settings($module))->getSettings();
+        $this->settings = (new Settings())->getAdminSettings($module);
         $this->tempDir = $temp_dir;
         $this->fileType = $file_type;
         $this->baseName = $this->settings['filename'] . "." . $this->settings['graphviz_config']['output'][$file_type]['extension'];

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -26,7 +26,7 @@ use Fisharebest\Webtrees\Tree;
  * @var ?           $module                 this module
  */
 
-$settings = (new Settings($module))->getSettings();
+$settings = (new Settings())->getAdminSettings($module);
 $nographviz = $vars['graphviz_bin'] == "";
 $xref = $individual->xref();
 ?>

--- a/resources/views/settings.phtml
+++ b/resources/views/settings.phtml
@@ -14,8 +14,8 @@ use Fisharebest\Webtrees\Http\RequestHandlers\ControlPanel;
  * @var array       $otypes                 output file type options
  * @var ?           $module                 this module
  */
-$settingsObj = new Settings($module);
-$settings = $settingsObj->getSettings();
+$settingsObj = new Settings();
+$settings = $settingsObj->getAdminSettings($module);
 ?>
 
 <?= view('components/breadcrumbs', ['links' => [route(ControlPanel::class) => I18N::translate('Control panel'), $title]]) ?>


### PR DESCRIPTION
If user is logged in, we now use the webtrees user preferences to save the settings instead of cookies. For logged out users, cookies are still used.

Closes #307