### PR TITLE
Refactor saved settings

### DIFF
--- a/app/Settings.php
+++ b/app/Settings.php
@@ -80,7 +80,11 @@ class Settings
                     if (Settings::shouldLoadSetting($preference)) {
                         $pref = $tree->getUserPreference(Auth::user(), Settings::PREFERENCE_PREFIX . $preference, "preference not set");
                         if ($pref != "preference not set") {
-                            $settings[$preference] = $pref;
+                            if ($pref == 'true' || $pref == 'false') {
+                                $settings[$preference] = ($pref == 'true');
+                            } else {
+                                $settings[$preference] = $pref;
+                            }
                         } else if ($preference == 'show_xref_individuals') {
                             $settings['first_run_xref_check'] = true;
                         }
@@ -128,7 +132,11 @@ class Settings
         } else {
             foreach ($settings as $preference => $value) {
                 if (Settings::shouldSaveSetting($preference)) {
-                    $tree->setUserPreference(Auth::user(), Settings::PREFERENCE_PREFIX . $preference, $value);
+                    if (gettype($value) == 'boolean') {
+                        $tree->setUserPreference(Auth::user(), Settings::PREFERENCE_PREFIX . $preference, ($value ? 'true' : 'false'));
+                    } else {
+                        $tree->setUserPreference(Auth::user(), Settings::PREFERENCE_PREFIX . $preference, $value);
+                    }
                 }
             }
         }
@@ -304,9 +312,9 @@ class Settings
     {
         $userSettings = $this->loadUserSettings($module, $tree);
         $settings = [];
-        foreach ($userSettings as $preference => $value) {
+        foreach ($this->defaultSettings as $preference => $value) {
             if (Settings::shouldSaveSetting($preference)) {
-                $settings[$preference] = $value;
+                $settings[$preference] = $userSettings[$preference];
             }
         }
         return json_encode($settings);

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -828,16 +828,16 @@ function loadSettings(data) {
                     setCheckStatus(document.getElementById('diagtype_combined'), settings[key] === 'combined');
                     break;
                 case 'birthdate_year_only':
-                    setCheckStatus(document.getElementById('bd_type_y'), settings[key] === '1');
-                    setCheckStatus(document.getElementById('bd_type_gedcom'), settings[key] === '');
+                    setCheckStatus(document.getElementById('bd_type_y'), settings[key]);
+                    setCheckStatus(document.getElementById('bd_type_gedcom'), !settings[key]);
                     break;
                 case 'death_date_year_only':
-                    setCheckStatus(document.getElementById('dd_type_y'), settings[key] === '1');
-                    setCheckStatus(document.getElementById('dd_type_gedcom'), settings[key] === '');
+                    setCheckStatus(document.getElementById('dd_type_y'), settings[key]);
+                    setCheckStatus(document.getElementById('dd_type_gedcom'), !settings[key]);
                     break;
                 case 'marr_date_year_only':
-                    setCheckStatus(document.getElementById('md_type_y'), settings[key] === '1');
-                    setCheckStatus(document.getElementById('md_type_gedcom'), settings[key] === '');
+                    setCheckStatus(document.getElementById('md_type_y'), settings[key]);
+                    setCheckStatus(document.getElementById('md_type_gedcom'), !settings[key]);
                     break;
                 case 'adv_people':
                     toggleAdvanced(document.getElementById('people-advanced-button'), 'people-advanced', settings[key] === 'adv_people');
@@ -848,8 +848,14 @@ function loadSettings(data) {
                 case 'adv_files':
                     toggleAdvanced(document.getElementById('files-advanced-button'), 'files-advanced', settings[key] === 'adv_files');
                     break;
+                // If option to use cart is not showing, don't load, but also don't show error
+                case 'use_cart':
+                // These options only exist if debug panel active - don't show error if not found
+                case 'enable_debug_mode':
+                case 'enable_graphviz':
+                    break;
                 default:
-                    showToast(key);
+                    showToast("E:" + CLIENT_ERRORS[1] + " " + key);
             }
         } else {
             if (el.type === 'checkbox' || el.type === 'radio') {
@@ -878,6 +884,11 @@ function setGraphvizAvailable(available) {
     graphvizAvailable = available;
 }
 
+/**
+ * This function exists for automated testing to access settings JSON without having to download the file
+ *
+ * @returns {string}
+ */
 function getSettingsJson() {
     return settings_json;
 }

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -668,6 +668,7 @@ $xref = $individual->xref();
             toggleCart(true);
         }
         setStateFastRelationCheck();
+        refreshIndisFromXREFS(false);
         document.getElementById("browser").value = "false";
         let lastDotStr, indiNum, famNum, messages;
 

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -62,7 +62,7 @@ $xref = $individual->xref();
 <?= $usegraphviz ? "" : "<script src=\"" . $module->assetUrl('javascript/jspdf.umd.min.js') . "\"></script>"; ?>
 <script type="text/javascript">
     const cartempty = <?= $cartempty ? "true" : "false" ?>;
-    const CLIENT_ERRORS = ["<?= I18N::translate('Your browser does not support exporting images this large. Please reduce number of records, reduce DPI setting, or use SVG option.') ?>"];
+    const CLIENT_ERRORS = ["<?= I18N::translate('Your browser does not support exporting images this large. Please reduce number of records, reduce DPI setting, or use SVG option.') ?>", "<?= I18N::translate('Unable to load setting ') ?>"];
     let autoUpdate = <?= $vars["auto_update"] ? 'true' : 'false' ?>;
     let debug_string = "";
     let TOMSELECT_URL = "";


### PR DESCRIPTION
When saving preferences, all values are converted to strings. The change to using preferences instead of cookies caused an unseen issue with boolean values. This change should resolve that though there are no user visible impacts from this.

Added error message if a setting in the settings file doesn't exist on the page.

XREF list now refreshed with changes in the advanced list of XREFs when clicking the main Update button when auto-update disabled.