### PR TITLE
Add tree name to downloaded settings file name

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -863,7 +863,7 @@ function downloadSettingsFileMenuAction(event) {
     }
     let file = new Blob([settings_json_string], {type: "text/plain"});
     let url = URL.createObjectURL(file);
-    downloadLink(url, settings['save_settings_name'] + ".json")
+    downloadLink(url, TREE_NAME + " - " + settings['save_settings_name'] + ".json")
 }
 
 /**


### PR DESCRIPTION
When downloading a settings file, these are specific to a tree. Added tree name to name of file.

As per comment https://github.com/Neriderc/GVExport/issues/330#issuecomment-1427599960