### PR TITLE
Add option to compress cookie

### DIFF
--- a/app/Cookie.php
+++ b/app/Cookie.php
@@ -56,7 +56,8 @@ class Cookie
             'expires' => time() + (3600 * 24 * 365),
             'samesite' => 'Strict'
         );
-        setcookie($this->name, $json_cookie, $cookie_options);
+        $compress = ($vars['compress_cookie'] ? gzdeflate($json_cookie) : $json_cookie);
+        setcookie($this->name, $compress, $cookie_options);
     }
 
     /**
@@ -68,7 +69,12 @@ class Cookie
     public function load($userDefaultVars): array
     {
         if (isset($_COOKIE[$this->name]) and $_COOKIE[$this->name] != "") {
-            $json_cookie = json_decode($_COOKIE[$this->name]);
+            try {
+                $decompressed = gzinflate($_COOKIE[$this->name]);
+            } catch (\Exception $e) {
+                $decompressed = $_COOKIE[$this->name];
+            }
+            $json_cookie = json_decode($decompressed);
             if (json_last_error() === JSON_ERROR_NONE) {
                 foreach ($json_cookie as $key => $value) {
                     $userDefaultVars[$key] = $value;

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -374,6 +374,7 @@ class Settings
             case 'space_base':
             case 'no_fams':
             case 'stop_proc':
+            case 'compress_cookie':
                 return false;
             case 'show_debug_panel':
             case 'filename':

--- a/config.php
+++ b/config.php
@@ -11,6 +11,7 @@ return array(
 	// 'graphviz_bin' => 'c:\\Graphviz2.17\\bin\\dot.exe', // for Windows (install dot.exe in a directory with no blank spaces)
 	// 'graphviz_bin' => '', // Uncomment this line if you don't have GraphViz installed on the server
 	'filename' => 'gvexport', // Output file name used for downloads
+	'compress_cookie' => true, // Whether cookie data should be compressed - particularly important if users can access multiple trees while logged out
 	'output_type' => 'svg', // Default output file type
 	'graph_dir' => 'LR', // Direction of graph. 'LR' for Left-to-right, 'TB' for Top-to-bottom
 	'mclimit' => '1', // Graphviz MCLIMIT setting - number of times to regenerate graph for reduced crossings


### PR DESCRIPTION
Cookies are limited to 4MB, and saving settings to a cookie takes about 2.5MB. This commit adds an option to compress the data using gzdeflate. Only available in config file, enabled by default. This reduces size by about 40%.

Note that only logged out users use cookies, and only one cookie is saved per tree.

Resolves #365