### PR TITLE
Change default zoom

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -316,7 +316,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             panzoomInst = panzoom(element, {
                 maxZoom: 4,
                 minZoom: fullZoom / 10,
-                initialZoom: fullZoom,
+                initialZoom: 1,
                 onTouch: function() {
                     // Fix links not working on mobile
                     return false; // tells the library to not preventDefault.


### PR DESCRIPTION
Changed default zoom level to always be the same, zoomed in on the starting person and surrounding individuals, regardless of diagram size.

Closes #456 