### PR TITLE
Remove font defaults

### DIFF
--- a/app/Dot.php
+++ b/app/Dot.php
@@ -479,7 +479,7 @@ class Dot {
 		$out .= "pagedir=\"LT\"\n";
 		$out .= "bgcolor=\"" . $this->settings['background_col'] . "\"\n";
 		$out .= "edge [ style=solid, arrowhead=normal, arrowtail=none];\n";
-        $out .= "node [ shape=plaintext font_size=\"" . $this->settings['font_size'] ."\" fontname=\"" . $this->settings["typefaces"][$this->settings["typeface"]] . ", " . $this->settings["typeface_fallback"][$this->settings["typeface"]] .", " . $this->settings["typefaces"][$this->settings["default_typeface"]] . ", Sans\"];\n";
+        $out .= "node [ shape=plaintext font_size=\"" . $this->settings['font_size'] ."\" fontname=\"" . $this->settings["typefaces"][$this->settings["typeface"]] . "\"];\n";
 		return $out;
 	}
 

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -49,7 +49,6 @@ class Settings
         $this->defaultSettings = include dirname(__FILE__) . "/../config.php";
         // Add options lists
         $this->defaultSettings['typefaces'] = [0 => "Arial", 10 => "Brush Script MT", 20 => "Courier New", 30 => "Garamond", 40 => "Georgia", 50 => "Tahoma", 60 => "Times New Roman", 70 => "Trebuchet MS", 80 => "Verdana"];
-        $this->defaultSettings['typeface_fallback'] = [0 => "Sans",  10 => "Cursive", 20 => "Monospace", 30 => "Serif", 40 => "Serif", 50 => "Sans", 60 => "Serif", 70 => "Sans", 80 => "Sans"];
         $this->defaultSettings['directions']['TB'] = "Top-to-bottom";
         $this->defaultSettings['directions']['LR'] = "Left-to-right";
         $this->defaultSettings['url_xref_treatment_options']['default'] = "Default";
@@ -409,7 +408,6 @@ class Settings
             case 'graphviz_config':
             case 'typefaces':
             case 'typeface_fallback':
-            case 'default_typeface':
             case 'directions':
             case 'url_xref_treatment_options':
             case 'use_abbr_places':

--- a/config.php
+++ b/config.php
@@ -62,7 +62,6 @@ return array(
 	'show_adv_appear' => false, // Whether to show advanced settings by default for Appearance section
 	'show_adv_files' => false, // Whether to show advanced settings by default for General settings section
 	'typeface' => 0, // Default font value, based on list of font 'typefaces'
-	'default_typeface' => 0, // Fallback font value, if above typeface not available
 	'font_colour_name' => '#333333',	// Default font colour for name
 	'font_colour_details' => '#555555',	// Default font colour for date/place of birth/death etc.
 	'font_size' => '10',	// Default font size for everything except name


### PR DESCRIPTION
Fixes issue with preferred names not displaying properly.

Issue still occurs when browser cannot load selected font, but most font options should now work ok on Windows, and the default Arial should work ok on all systems.