### PR TITLE
Resolve issue with webtrees 2.1.19

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -457,7 +457,7 @@ function showGraphvizUnsupportedMessage() {
 
 // This function is run when the page is loaded
 function pageLoaded(Url) {
-    TOMSELECT_URL = document.getElementById('pid').getAttribute("data-url") + "&query=";
+    TOMSELECT_URL = document.getElementById('pid').getAttribute("data-wt-url") + "&query=";
     loadURLXref(Url);
     loadUrlToken(Url);
     loadXrefList(TOMSELECT_URL, 'xref_list', 'indi_list');


### PR DESCRIPTION
Webtrees 2.1.19 has a backend change that breaks person selection for GVExport. This update resolves it, but breaks support for previous webtrees versions.