### PR TITLE
Fix auth issue

### DIFF
--- a/module.php
+++ b/module.php
@@ -174,6 +174,8 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
     public function getChartAction(ServerRequestInterface $request): ResponseInterface
     {
         $tree = $request->getAttribute('tree');
+        Auth::checkComponentAccess($this, ModuleChartInterface::class, $tree, Auth::user());
+
         assert($tree instanceof Tree);
         if (isset($request->getQueryParams()['xref'])) {
             $xref = $request->getQueryParams()['xref'];


### PR DESCRIPTION
If a user did not have access to the module assigned to them, they could still view the module if they went to the URL.

This fixes this issue by adding an auth check when loading the page.

Resolves #479 