### PR TITLE
Refactor settings, enable shared note colour for logged out users

### DIFF
--- a/app/ApiHandler.php
+++ b/app/ApiHandler.php
@@ -180,11 +180,20 @@ class ApiHandler
     {
         if (isset($this->json['settings_id']) && (ctype_alnum((string) $this->json['settings_id']) || in_array($this->json['settings_id'], [Settings::ID_ALL_SETTINGS, Settings::ID_MAIN_SETTINGS]))) {
             $settings = new Settings();
-            try {
-                $this->response_data['settings'] = ($this->json['settings_id'] == Settings::ID_ALL_SETTINGS ? $settings->getAllSettingsJson($this->module, $this->tree) : $settings->getSettingsJson($this->module, $this->tree, $this->json['settings_id']));
+            // Treat loggged out users special if requesting ID_MAIN_SETTINGS
+            if ($this->json['settings_id'] == Settings::ID_MAIN_SETTINGS && Auth::user()->id() == Settings::GUEST_USER_ID) {
+                $vars = Validator::parsedBody($this->request)->array('vars');
+                $form = new FormSubmission();
+                $settings_response = $form->load($vars, $this->module);
+                $this->response_data['settings'] = $settings->getJsonFromSettings($settings_response);
                 $this->response_data['success'] = true;
-            } catch (Exception $e) {
-                $this->setFailResponse('Invalid JSON', 'E9');
+            } else {
+                try {
+                    $this->response_data['settings'] = ($this->json['settings_id'] == Settings::ID_ALL_SETTINGS ? $settings->getAllSettingsJson($this->module, $this->tree) : $settings->getSettingsJson($this->module, $this->tree, $this->json['settings_id']));
+                    $this->response_data['success'] = true;
+                } catch (Exception $e) {
+                    $this->setFailResponse('Invalid JSON', 'E9');
+                }
             }
         } else {
             $this->setFailResponse('Invalid settings ID', 'E6');

--- a/app/ApiHandler.php
+++ b/app/ApiHandler.php
@@ -395,7 +395,7 @@ class ApiHandler
     }
 
     /**
-     * Retrieve the help information from appropriate view file
+     * Retrieve the shared note form
      *
      * @return void
      */

--- a/app/Cookie.php
+++ b/app/Cookie.php
@@ -49,7 +49,7 @@ class Cookie
     public function set($vars) {
         $cookieArray = [];
         foreach ($vars as $preference => $value) {
-            if (Settings::shouldSaveSetting($preference)) {
+            if (Settings::shouldSaveSetting($preference, Settings::CONTEXT_COOKIE)) {
                 $cookieArray[$preference] = $value;
             }
         }

--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -160,6 +160,8 @@ class FormSubmission
 
         if (isset($vars['use_cart'])) {
             $settings['use_cart'] = ($vars['use_cart'] !== "ignorecart");
+        } else {
+            $settings['use_cart'] = false;
         }
 
         if (isset($vars['show_adv_people'])) {
@@ -268,6 +270,8 @@ class FormSubmission
         }
         if (isset($vars['sharednote_col_data']) && $this->isValidJSON($vars["sharednote_col_data"])) {
             $settings['sharednote_col_data'] = $vars["sharednote_col_data"];
+        } else {
+            $settings['sharednote_col_data'] = '[]';
         }
         if (isset($vars["indi_background_col"]) && $this->isValidColourHex($vars["indi_background_col"])) {
             $settings['indi_background_col'] = $vars["indi_background_col"];

--- a/module.php
+++ b/module.php
@@ -185,10 +185,12 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
         $individual = $this->getIndividual($tree, $tree->significantIndividual(Auth::user(), $xref)->xref());
 		$userDefaultVars = (new Settings())->getAdminSettings($this);
         $settings = new Settings();
+        $userDefaultVars['first_render'] = true;
         if (isset($_REQUEST['reset'])){
             if (!$userDefaultVars['enable_graphviz'] && $userDefaultVars['graphviz_bin'] != "") {
                 $userDefaultVars['graphviz_bin'] = "";
             }
+            $userDefaultVars['first_render'] = false; // Allow settings to be overwritten by defaults
         } else if (isset($_REQUEST['t'])) {
             try {
                 if (ctype_alnum($_REQUEST['t'])) {
@@ -208,6 +210,10 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
             $userDefaultVars = $settings->loadUserSettings($this, $tree);
         }
         $otypes = $this->getOTypes($userDefaultVars);
+
+        if (!isset($userDefaultVars['first_render'])) {
+            $userDefaultVars['first_render'] = true;
+        }
 
         return $this->viewResponse($this->name() . '::page', [
             'tree'          => $tree,

--- a/resources/javascript/MainPage/Data.js
+++ b/resources/javascript/MainPage/Data.js
@@ -453,6 +453,53 @@ const Data = {
                 Data.storeSettings.saveSettings(id);
             }
 
+        },
+
+        /**
+         * Retrieve settings from browser storage
+         *
+         * @param id
+         * @returns {Promise<{} | {} | any | undefined | void>}
+         */
+        getSettingsClient(id = ID_ALL_SETTINGS) {
+            return getTreeName().then(async (treeName) => {
+                try {
+                    if (id === ID_ALL_SETTINGS) {
+                        if (localStorage.getItem(SETTINGS_ID_LIST_NAME + "_" + treeName)) {
+                            let settings_list = localStorage.getItem(SETTINGS_ID_LIST_NAME + "_" + treeName);
+                            let ids = settings_list.split(',');
+                            let promises = ids.map(id_value => Data.storeSettings.getSettingsClient(id_value))
+                            let results = await Promise.all(promises);
+                            let settings = {};
+                            for (let i = 0; i < ids.length; i++) {
+                                let id_value = ids[i];
+                                let userSettings = results[i];
+                                if (userSettings === null) {
+                                    return Promise.reject('User settings null');
+                                } else {
+                                    settings[id_value] = {};
+                                    settings[id_value]['name'] = userSettings['save_settings_name'];
+                                    settings[id_value]['id'] = id_value;
+                                    settings[id_value]['settings'] = JSON.stringify(userSettings);}
+                            }
+                            return settings;
+                        } else {
+                            return {};
+                        }
+                    } else {
+                        try {
+                            return JSON.parse(localStorage.getItem("GVE_Settings_" + treeName + "_" + id));
+                        } catch(e) {
+                            return Promise.reject(e);
+                        }
+                    }
+
+                } catch(e) {
+                    return Promise.reject(e);
+                }
+            }).catch((e) => {
+                UI.showToast(ERROR_CHAR + e);
+            });
         }
     }
 }

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -920,22 +920,6 @@ function getTreeName() {
     }
 }
 
-function saveSettingsClient(id) {
-    return Promise.all([saveSettingsServer(true), getTreeName()])
-        .then(([, treeNameLocal]) => {
-            return getSettings(ID_MAIN_SETTINGS).then((settings_json_string) => [settings_json_string,treeNameLocal]);
-        })
-        .then(([settings_json_string, treeNameLocal]) => {
-            try {
-                JSON.parse(settings_json_string);
-            } catch (e) {
-                return Promise.reject("Invalid JSON 2");
-            }
-            localStorage.setItem("GVE_Settings_" + treeNameLocal + "_" + id, settings_json_string);
-            return Promise.resolve();
-        });
-}
-
 function getIdLocal() {
     return getTreeName().then((treeName) => {
         let next_id;

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -153,7 +153,7 @@ function addIndiToStopList(xref) {
     const regex = new RegExp(`(?<=,|^)(${xref})(?=,|$)`);
     if (!regex.test(list.value.replaceAll(" ','"))) {
         appendXrefToList(xref, 'stop_xref_list');
-        loadIndividualDetails(TOMSELECT_URL, xref, 'stop_indi_list');
+        loadIndividualDetails(TOMSELECT_URL, xref, 'stop_indi_list').then(r => {});
     }
     Form.clearSelect('stop_pid');
 }
@@ -299,7 +299,7 @@ function toggleFullscreen() {
         document.msFullscreenElement
     ) {
         if (document.exitFullscreen) {
-            document.exitFullscreen();
+            document.exitFullscreen().then(r => {});
         } else if (document.mozCancelFullScreen) {
             document.mozCancelFullScreen();
         } else if (document.webkitExitFullscreen) {
@@ -310,7 +310,7 @@ function toggleFullscreen() {
     } else { // Not full screen, so go fullscreen
         const element = document.getElementById('render-container');
         if (element.requestFullscreen) {
-            element.requestFullscreen();
+            element.requestFullscreen().then(r => {});
         } else if (element.mozRequestFullScreen) {
             element.mozRequestFullScreen();
         } else if (element.webkitRequestFullscreen) {
@@ -459,13 +459,19 @@ function showGraphvizUnsupportedMessage() {
 function pageLoaded(Url) {
 
     // Load settings for logged out user
-    isUserLoggedIn().then((loggedIn) => {
-        if (!loggedIn) {
-            Data.storeSettings.getSettingsClient(ID_MAIN_SETTINGS).then((obj) => {
-                loadSettings(JSON.stringify(obj));
-            })
-        }
-    });
+    if (firstRender) {
+        isUserLoggedIn().then((loggedIn) => {
+            if (!loggedIn) {
+                Data.storeSettings.getSettingsClient(ID_MAIN_SETTINGS).then((obj) => {
+                    if (obj !== null) {
+                        loadSettings(JSON.stringify(obj));
+                    } else {
+                        firstRender = false;
+                    }
+                })
+            }
+        });
+    }
 
     TOMSELECT_URL = document.getElementById('pid').getAttribute("data-wt-url") + "&query=";
     loadURLXref(Url);
@@ -673,7 +679,7 @@ function loadSettings(data, isNamedSetting = false) {
     setSavedDiagramsPanel();
     Form.showHide(document.getElementById('arrow_group'),document.getElementById('colour_arrow_related').checked)
     Form.showHide(document.getElementById('startcol_option'),document.getElementById('highlight_start_indis').checked)
-
+    toggleUpdateButton();
     if (autoUpdatePrior) {
         if (firstRender) {
             firstRender = false;
@@ -930,7 +936,7 @@ function setSavedDiagramsPanel() {
 function copyToClipboard(textToCopy) {
     // navigator clipboard api needs a secure context (https)
     if (navigator.clipboard && window.isSecureContext) {
-        // navigator clipboard api method'
+        // navigator clipboard api method
         return navigator.clipboard.writeText(textToCopy);
     } else {
         // text area method

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -844,59 +844,6 @@ function loadSettingsDetails() {
     );
 }
 
-function saveSettingsAdvanced(userPrompted = false) {
-    let settingsList = document.getElementsByClassName('settings_list_item');
-    let settingsName = document.getElementById('save_settings_name').value;
-    if (settingsName === '') settingsName = "Settings";
-    let id = null;
-    for (let i=0; i<settingsList.length; i++) {
-        if (settingsList[i].getAttribute('data-name') === settingsName) {
-            id = settingsList[i].getAttribute('data-id');
-        }
-    }
-    if (id !== null) {
-        if (userPrompted) {
-            document.getElementById('modal').remove();
-        } else {
-            let message = TRANSLATE["Overwrite settings '%s'?"].replace('%s', settingsName);
-            let buttons = '<div class="modal-button-container"><button class="btn btn-secondary modal-button" onclick="document.getElementById(' + "'modal'" + ').remove()">' + TRANSLATE['Cancel'] + '</button><button class="btn btn-primary modal-button" onclick="saveSettingsAdvanced(true)">' + TRANSLATE['Overwrite'] + '</button></div>';
-            showModal('<div class="modal-container">' + message + '<br>' + buttons + '</div>');
-            return false;
-        }
-    }
-
-    isUserLoggedIn().then((loggedIn) => {
-        if (loggedIn) {
-            return saveSettingsServer(false, id).then((response)=>{
-                try {
-                    let json = JSON.parse(response);
-                    if (json.success) {
-                        return response;
-                    } else {
-                        return Promise.reject(ERROR_CHAR + json.errorMessage);
-                    }
-                } catch (e) {
-                    return Promise.reject("Failed to load response: " + e);
-                }
-            });
-        } else {
-            if (id === null) {
-                return getIdLocal().then((newId) => {
-                    return saveSettingsClient(newId);
-                });
-            } else {
-                return saveSettingsClient(id);
-            }
-        }
-    }).then(() => {
-        loadSettingsDetails();
-        document.getElementById('save_settings_name').value = "";
-    }).catch(
-        error => UI.showToast(error)
-    );
-
-}
-
 function loadUrlToken(Url) {
     const token = Url.getURLParameter("t");
     if (token !== '') {

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -994,7 +994,6 @@ function getIdLocal() {
         let next_id;
         let settings_list = localStorage.getItem(SETTINGS_ID_LIST_NAME + "_" + treeName);
         if (settings_list) {
-            settings_list = localStorage.getItem(SETTINGS_ID_LIST_NAME + "_" + treeName);
             let ids = settings_list.split(',');
             let last_id = ids[ids.length - 1];
             next_id = (parseInt(last_id, 36) + 1).toString(36);

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -210,18 +210,18 @@ function removeSearchOptions() {
     document.getElementById('stop_xref_list').value.split(',').forEach(function (xref) {
         removeSearchOptionFromList(xref, 'stop_pid')
     });
-    isUserLoggedIn().then((loggedIn) => {
-        if (loggedIn) {
-            // Remove option for shared note if already in list
-            let notes = document.getElementById('sharednote_col_data').value;
-            if (notes !== '') {
-                let json = JSON.parse(notes);
-                json.forEach(item => {
-                    removeSearchOptionFromList('@' + item.xref + '@', 'sharednote_col_add');
-                });
-            }
+    // Remove option for shared note if already in list
+    let notes = document.getElementById('sharednote_col_data').value;
+    if (notes !== '') {
+        try {
+            let json = JSON.parse(notes);
+            json.forEach(item => {
+                removeSearchOptionFromList('@' + item.xref + '@', 'sharednote_col_add');
+            });
+        } catch (e) {
+            document.getElementById('sharednote_col_data').value = '';
         }
-    });
+    }
 
     // Remove option when searching diagram if indi not in diagram
     let dropdown = document.getElementById('diagram_search_box');
@@ -483,11 +483,7 @@ function pageLoaded(Url) {
     document.querySelector(".sidebar_toggle a").addEventListener("click", UI.showSidebar);
     UI.helpPanel.init();
     UI.fixTheme();
-    isUserLoggedIn().then((loggedIn) => {
-        if (loggedIn) {
-            Form.sharedNotePanel.init();
-        }
-    });
+    Form.sharedNotePanel.init();
 
     // Form change events
     const form = document.getElementById('gvexport');
@@ -585,6 +581,8 @@ function toBool(value) {
     }
 }
 function loadSettings(data, isNamedSetting = false) {
+    let autoUpdatePrior = autoUpdate;
+    autoUpdate = false;
     let settings;
     try {
         settings = JSON.parse(data);
@@ -666,7 +664,9 @@ function loadSettings(data, isNamedSetting = false) {
     Form.showHide(document.getElementById('arrow_group'),document.getElementById('colour_arrow_related').checked)
     Form.showHide(document.getElementById('startcol_option'),document.getElementById('highlight_start_indis').checked)
 
-    if (autoUpdate) {
+    if (autoUpdatePrior) {
+        firstRender = false;
+        autoUpdate = true;
         updateRender();
     }
     refreshIndisFromXREFS(false);

--- a/resources/views/MainPage/Appearance/TileDesign.phtml
+++ b/resources/views/MainPage/Appearance/TileDesign.phtml
@@ -106,9 +106,7 @@ use Fisharebest\Webtrees\Auth;
                 <?= view($module->name() . '::MainPage/Appearance/TileDesign/Subgroup',['view' => $module->name() . '::MainPage/Appearance/TileDesign/ColourPickerList', 'view_options' => ['vars' => $vars, 'admin' => $admin, 'group' => 'border', 'field' => 'vitals', 'select_id' => 'stripe_col_type', 'option_id' => Settings::OPTION_BORDER_VITAL_COLOUR, 'picker_list' => ['indi_border_dead_col' => 'Deceased', 'indi_border_living_col' => 'Living']]]); ?>
                 <?= view($module->name() . '::MainPage/Appearance/TileDesign/Subgroup',['view' => $module->name() . '::MainPage/Appearance/TileDesign/AgeColourSubgroup', 'view_options' => ['module' => $module, 'vars' => $vars, 'admin' => $admin, 'group' => 'border', 'field' => 'age', 'select_id' => 'border_col_type', 'option_id' => Settings::OPTION_BORDER_AGE_COLOUR, 'picker_list' => ['indi_border_age_low_col' => 'Low age colour', 'indi_border_age_high_col' => 'High age colour', 'indi_border_age_unknown_col' => 'Unknown age colour']]]); ?>
             </div>
-            <?php
-                if (Auth::user()->id() !== Settings::GUEST_USER_ID) {
-            ?>
+
             <div class="col-auto margin-bottom">
                 <input type="checkbox" name="vars[sharednote_col_enable]" onclick="Form.showHide(document.getElementById('subgroup_note_colour'),this.checked)" id="sharednote_col_enable" value="sharednote_col_enable" <?= $vars["sharednote_col_enable"] ? 'checked' : '' ?>><label for="sharednote_col_enable" class="check-list width-90pc"><?= I18N::translate('Style individuals based on shared note') ?></label>
 
@@ -137,7 +135,6 @@ use Fisharebest\Webtrees\Auth;
                     <?php } ?>
                 </div>
             </div>
-            <?php } ?>
             <div class="col-auto">
                 <input type="color" class="picker" name="vars[male_col]" id="male_col" value="<?= e($vars["male_col"]); ?>" /><label for="male_col" class="picker-label"><?= I18N::translate('Male individuals') ?></label>
             </div>

--- a/resources/views/MainPage/GeneralSettings/SaveSettings.phtml
+++ b/resources/views/MainPage/GeneralSettings/SaveSettings.phtml
@@ -18,7 +18,7 @@ use Fisharebest\Webtrees\I18N;
     <div class="input-group mt-1">
         <input type="text" class="form-control" name="vars[save_settings_name]" id="save_settings_name" placeholder="<?= I18N::translate('Settings name'); ?>">
         <div class="input-group-append">
-            <button id="save_settings_button" type="button" class="btn btn-outline-secondary" onclick="saveSettingsAdvanced()"><?= I18N::translate('Save') ?></button>
+            <button id="save_settings_button" type="button" class="btn btn-outline-secondary" onclick="Data.storeSettings.saveSettingsAdvanced()"><?= I18N::translate('Save') ?></button>
         </div>
     </div>
     <?php } ?>

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -214,6 +214,12 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     });
 
     function updateRender() {
+        // Update settings in browser storage if logged out
+        isUserLoggedIn().then((loggedIn) => {
+            if (!loggedIn) {
+                Data.storeSettings.saveSettingsClient('_MAIN_');``
+            }
+        });
         // Set browser value to true so we can return other info with DOT file
         // that can't be included with downloaded file
         document.getElementById("browser").value = "true";

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -34,9 +34,11 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     let download_file_name = "<?= e($settings['filename']); ?>";
     let url_xref_treatment = "<?= e($vars['url_xref_treatment']); ?>";
     let shared_note_default = "<?= $vars['sharednote_col_default']; ?>";
+    let firstRender = true;
     const TREE_NAME = "<?= e($tree->name()); ?>";
     const TREE_FAVORITES_MODULE_ACTIVE = <?= $module->module_service->findByInterface(FamilyTreeFavoritesModule::class)->first() === null || !Auth::isManager($tree) ? "false" : "true" ?>;
     const MY_FAVORITES_MODULE_ACTIVE = <?= $module->module_service->findByInterface(UserFavoritesModule::class)->first() === null ? "false" : "true" ?>;
+
 </script>
 <h2 class="wt-page-title">
     <?= $title ?>
@@ -214,6 +216,16 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     });
 
     function updateRender() {
+        // Don't overwrite browser settings with default settings
+        if (!firstRender) {
+            // Update settings in browser storage if logged out
+            isUserLoggedIn().then((loggedIn) => {
+                if (!loggedIn) {
+                    Data.storeSettings.saveSettingsClient('_MAIN_');
+                }
+            });
+        }
+
         // Update settings in browser storage if logged out
         isUserLoggedIn().then((loggedIn) => {
             if (!loggedIn) {
@@ -295,6 +307,9 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             if (lastDotStr.indexOf("digraph WT_Graph {") !== -1) {
                 messages = jsonResponse.messages;
                 debug_string = jsonResponse.enable_debug_mode;
+                if (firstRender) {
+                    loadSettings(jsonResponse.settings);
+                }
             }
             const images = [...lastDotStr.matchAll(/<IMG[^>]+SRC="([^"]*)/gmi)].map(function (matches) {
                 return {

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -226,12 +226,6 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             });
         }
 
-        // Update settings in browser storage if logged out
-        isUserLoggedIn().then((loggedIn) => {
-            if (!loggedIn) {
-                Data.storeSettings.saveSettingsClient('_MAIN_');``
-            }
-        });
         // Set browser value to true so we can return other info with DOT file
         // that can't be included with downloaded file
         document.getElementById("browser").value = "true";

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -33,7 +33,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     let download_file_name = "<?= e($settings['filename']); ?>";
     let url_xref_treatment = "<?= e($vars['url_xref_treatment']); ?>";
     let shared_note_default = "<?= $vars['sharednote_col_default']; ?>";
-    let firstRender = true;
+    let firstRender = <?= $vars['first_render'] ? 'true' : 'false'; ?>;
     const TREE_NAME = "<?= e($tree->name()); ?>";
     const TREE_FAVORITES_MODULE_ACTIVE = <?= $module->module_service->findByInterface(FamilyTreeFavoritesModule::class)->first() === null || !Auth::isManager($tree) ? "false" : "true" ?>;
     const MY_FAVORITES_MODULE_ACTIVE = <?= $module->module_service->findByInterface(UserFavoritesModule::class)->first() === null ? "false" : "true" ?>;

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -30,7 +30,6 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     let autoUpdate = <?= $vars["auto_update"] ? 'true' : 'false' ?>;
     let debug_string = "";
     let TOMSELECT_URL = "";
-    let settings_json = "";
     let download_file_name = "<?= e($settings['filename']); ?>";
     let url_xref_treatment = "<?= e($vars['url_xref_treatment']); ?>";
     let shared_note_default = "<?= $vars['sharednote_col_default']; ?>";
@@ -221,7 +220,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             // Update settings in browser storage if logged out
             isUserLoggedIn().then((loggedIn) => {
                 if (!loggedIn) {
-                    Data.storeSettings.saveSettingsClient('_MAIN_');
+                    Data.storeSettings.saveSettingsClient(ID_MAIN_SETTINGS);
                 }
             });
         }
@@ -301,9 +300,6 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             if (lastDotStr.indexOf("digraph WT_Graph {") !== -1) {
                 messages = jsonResponse.messages;
                 debug_string = jsonResponse.enable_debug_mode;
-                if (firstRender) {
-                    loadSettings(jsonResponse.settings);
-                }
             }
             const images = [...lastDotStr.matchAll(/<IMG[^>]+SRC="([^"]*)/gmi)].map(function (matches) {
                 return {


### PR DESCRIPTION
Changes to logged out users where settings are stored in browser, a small number of visible settings are stored in cookie so they are set when page loads. Remaining settings are loaded via javascript after page has loaded.

This required some changes to how things work.

API request for settings for logged out users now takes this from the form submission not from the cookie.

Added cookie context for settings to set which fields are in cookie.

Some changes to rendering diagram - first render does not store data to avoid saving defaults over user settings

Add ability for logged out users to use shared note colours.

Closes #463 