### PR TITLE
Refactor colours to use themes

### DIFF
--- a/app/MainPage.php
+++ b/app/MainPage.php
@@ -44,7 +44,7 @@ class MainPage
      */
     public static function addLabel(string $for, string $text, bool $help = TRUE): string
     {
-        return '<label class="col-sm-4 col-form-label wt-page-options-label label-group" for="' . $for .'"><span class="label-text">' . I18N::translate($text) . "</span>" . ($help ? MainPage::addInfoButton($text) : "") . '</label>';
+        return '<label class="col-sm-4 col-form-label sidebar-labels label-group" for="' . $for .'"><span class="label-text">' . I18N::translate($text) . "</span>" . ($help ? MainPage::addInfoButton($text) : "") . '</label>';
     }
 
     /**

--- a/resources/css/gvexport.css
+++ b/resources/css/gvexport.css
@@ -8,10 +8,31 @@
     border-top: 1px solid black;
     border-right: 1px solid black;
     padding-top: 0.5rem;
-    background-color: #fff;
+    background-color: var(--bs-tertiary-bg);
     display: flex;
     flex-direction: column;
 }
+
+.sidebar-labels {
+    background-color: var(--bs-secondary-bg);
+    color: var(--fgColor-default, --bs-secondary-text-emphasis, white);
+    margin-left: 2px;
+    margin-right: -2px;
+}
+
+.theme-webtrees-labels {
+    background-color: #81a9cb !important;
+    color: white;
+}
+
+.theme-webtrees-options {
+    background-color: #edf7f9 !important;
+}
+
+.theme-primer-listitem {
+    background-color: white;
+}
+
 
 .no-right-margin {
     margin-right: 0px !important;
@@ -54,7 +75,7 @@
     border-top: 1px solid black;
     border-left: 1px solid black;
     padding: 0.5rem;
-    background-color: #fff;
+    background-color: var(--bs-tertiary-bg);
     display: flex;
     flex-direction: column;
 }
@@ -220,10 +241,16 @@
 .indi_list_item, .settings_list_item {
     position: relative;
     border: 1px solid;
-    background-color: white;
+    border-color: var(--bs-border-color);
+    background-color: var(--data-gray-color-muted, var(--bs-body-bg, white));
     border-radius: 5px;
     margin: 3px;
     width: 100%;
+}
+
+.options-panel-background {
+    background-color: var(--bs-tertiary-bg);
+    padding: .25rem .75rem;
 }
 
 span.NAME {
@@ -391,7 +418,7 @@ span.NAME {
     position: absolute;
     padding: 5px;
     z-index: 300;
-    background-color: white;
+    background-color: var(--bs-tertiary-bg);
     border-color: #333333;
     border-width: 1px;
     border-style: solid;
@@ -402,18 +429,19 @@ span.NAME {
     top: 28px;
 }
 
+
 #context_menu::after, .settings_ellipsis_menu::after {
     content: "";
     position: absolute;
-    top: -1px; /* move up 20px */
-    right: -1px; /* move right 20px */
-    width: 10px; /* width of the corner */
-    height: 10px; /* height of the corner */
+    top: -1px;
+    right: -1px;
+    width: 10px;
+    height: 10px;
     border-color: transparent #333333 transparent transparent;
     border-style: solid;
     border-width: 1px;
 }
-
+/* pointy arrow bit of menu */
 #context_menu::before, .settings_ellipsis_menu::before {
     content: "";
     position: absolute;
@@ -421,7 +449,7 @@ span.NAME {
     right: var(--gve-context-right);
     width: 10px;
     height: 10px;
-    background-color: white;
+    background-color: var(--bs-tertiary-bg);
     border: 1px solid var(--gve-context-up);
     border-bottom-color: var(--gve-context-down);
     border-left-color: var(--gve-context-down);

--- a/resources/javascript/MainPage/UI.js
+++ b/resources/javascript/MainPage/UI.js
@@ -578,30 +578,36 @@ const UI = {
      *
      */
     fixTheme() {
-        let elements = document.querySelectorAll('.advanced-settings-btn');
-        let baseColour = getComputedStyle(document.querySelector('.wt-page-options-value')).backgroundColor;
-        let replaceColour = getComputedStyle(document.querySelector('.btn-primary')).backgroundColor;
-        let primaryButton = document.querySelector('.btn-primary');
-        let replaceTextColour;
-        if (primaryButton !== null) {
-            replaceTextColour = getComputedStyle(primaryButton).color;
-        }
-        for (let i=0; i<elements.length; i++) {
-            if (getComputedStyle(elements[i]).backgroundColor === baseColour) {
-                // If no background-color because background is used instead, then use this.
-                // Resolves issue where background-color is transparent because background gradient being used
-                if (replaceColour === 'rgba(0, 0, 0, 0)') {
-                    let searchButton = document.querySelector('.wt-header-search-button');
-                    if (searchButton !== null) {
-                        elements[i].style.background = getComputedStyle(searchButton).background;
-                    }
-                } else {
-                    elements[i].style.backgroundColor = replaceColour;
-                }
-                if (primaryButton !== null) {
-                    elements[i].style.color = replaceTextColour;
+        try {
+            // first, what theme?
+            let theme = '';
+            let dropdownMenu = document.querySelector('.menu-theme');
+            if (dropdownMenu) {
+                let activeItem = dropdownMenu.querySelector('.dropdown-item.active');
+                if (activeItem) {
+                    theme = activeItem.textContent.trim();
                 }
             }
+
+            if (theme === 'webtrees') {
+                // Set the webtrees blue colours that are for some reason not stored in a css variable
+                // We do this here rather than hard coding the colour we want so we don't break other themes.
+                let elements = document.querySelectorAll('.sidebar-labels');
+                for (let i = 0; i < elements.length; i++) {
+                    elements[i].classList.add('theme-webtrees-labels');
+                }
+
+                elements = document.querySelectorAll('.options-panel-background');
+                for (let i = 0; i < elements.length; i++) {
+                    elements[i].classList.add('theme-webtrees-options');
+                }
+
+                // Make colour behind headings white instead of theme colour leaking through
+                let form = document.getElementById('gvexport');
+                form.style.background = '#ffffff';
+            }
+        } catch (e) {
+            // ignore if theme doesn't like us messing with it
         }
     },
 

--- a/resources/views/ControlPanel/DebugPanel.phtml
+++ b/resources/views/ControlPanel/DebugPanel.phtml
@@ -11,17 +11,17 @@ use vendor\WebtreesModules\gvexport\Settings;
 
 <div class="row no-right-margin form-group">
     <?= MainPage::addLabel('enable_debug_mode', 'Debug mode', FALSE); ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <label for="enable_debug_mode"><?= I18N::translate('Show debug panel') ?></label>
         <input type="checkbox" name="vars[show_debug_panel]" id="show_debug_panel" value="show_debug_panel" <?= $vars["show_debug_panel"] ? 'checked' : '' ?>><br>
     </div>
     <?= MainPage::addLabel('enable_debug_mode', 'Debug mode', FALSE); ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <label for="enable_debug_mode"><?= I18N::translate('Enable debug mode') ?></label>
         <input type="checkbox" name="vars[enable_debug_mode]" id="enable_debug_mode" value="enable_debug_mode" <?= $vars["enable_debug_mode"] ? 'checked' : '' ?>><br>
     </div>
     <?= MainPage::addLabel('enable_graphviz', 'Graphviz', FALSE); ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <label for="enable_graphviz"><?= I18N::translate('Use Graphviz on server') ?></label>
         <input type="checkbox" name="vars[enable_graphviz]" id="enable_graphviz" value="enable_graphviz" onclick="setGraphvizAvailable(this.value==='enable_graphviz');" <?= $vars["enable_graphviz"] ? 'checked' : '' ?> <?= (new Settings())->getDefaultSettings()['graphviz_bin'] == "" ? "disabled" : ""; ?>><br></div>
 </div>

--- a/resources/views/MainPage/Appearance.phtml
+++ b/resources/views/MainPage/Appearance.phtml
@@ -38,4 +38,4 @@ use vendor\WebtreesModules\gvexport\GVExport;use vendor\WebtreesModules\gvexport
         <?= view($module->name() . '::MainPage/Appearance/DiagramAdvanced',['vars' => $vars, 'settings' => $settings, 'usegraphviz' => $usegraphviz, 'individual' => $individual, 'admin' => $admin]); ?>
     </div>
 </div>
-<a id="appearance-advanced-button" onclick="Form.toggleAdvanced(this, 'appearance-advanced')"><div class="wt-page-options-label advanced-settings-btn"><?= ($vars["show_adv_appear"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_appear"] ? ' ↑' : ' ↓'); ?></div></a>
+<a id="appearance-advanced-button" onclick="Form.toggleAdvanced(this, 'appearance-advanced')"><div class="sidebar-labels advanced-settings-btn"><?= ($vars["show_adv_appear"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_appear"] ? ' ↑' : ' ↓'); ?></div></a>

--- a/resources/views/MainPage/Appearance/DiagramAdvanced.phtml
+++ b/resources/views/MainPage/Appearance/DiagramAdvanced.phtml
@@ -11,9 +11,9 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('', 'Diagram', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div onclick="Form.showHideSubgroup('dpi_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Diagram DPI'); ?></div>
-    <div id="dpi_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="dpi_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="row">
             <label for="dpi"><?= I18N::translate('DPI') ?></label>
             <div class="col-auto">
@@ -24,7 +24,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
 
     <div onclick="Form.showHideSubgroup('spacing_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Spacing'); ?></div>
-    <div id="spacing_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="spacing_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="row">
             <label for="ranksep"><?= I18N::translate('Between generations') ?></label>
             <div class="col-auto">
@@ -40,7 +40,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
 
     <div onclick="Form.showHideSubgroup('diagtype_combined_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Layout'); ?></div>
-    <div id="diagtype_combined_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="diagtype_combined_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="row">
             <div><?= I18N::translate('Partner position') ?>:</div>
             <div class="font-small">(<?= I18N::translate('Combined diagram type only') ?>)</div>
@@ -58,7 +58,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
 
     <div onclick="Form.showHideSubgroup('diagram_colours_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Diagram colours'); ?></div>
-    <div id="diagram_colours_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="diagram_colours_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="row">
             <div class="col-sm-12 col-auto">
                 <input type="color" class="picker" name="vars[background_col]" id="background_col" value="<?= e($vars["background_col"]); ?>" /><label for="background_col" class="picker-label"><?= I18N::translate('Diagram background colour') ?></label>
@@ -68,7 +68,7 @@ use Fisharebest\Webtrees\I18N;
             </div>
             <div class="padding-left-10">
                 <input type="checkbox" name="vars[colour_arrow_related]" onclick="Form.showHide(document.getElementById('arrow_group'),this.checked)" id="colour_arrow_related" value="colour_arrow_related" <?= $vars["colour_arrow_related"] ? 'checked' : '' ?>><label for="colour_arrow_related" class="check-list width-90pc"><?= I18N::translate('Show blood relationship in different colour') ?></label>
-                <div id="arrow_group" class="setting_subgroup col-auto wt-page-options-value" <?= !$vars["colour_arrow_related"] ? 'style="display:none;"' : '' ?>>
+                <div id="arrow_group" class="setting_subgroup col-auto options-panel-background" <?= !$vars["colour_arrow_related"] ? 'style="display:none;"' : '' ?>>
                     <div class="sub-group">
                         <input type="color" class="picker" name="vars[arrows_related]" id="arrows_related" value="<?= e($vars["arrows_related"]); ?>" /><label for="arrows_related" class="picker-label"><?= I18N::translate('Related by birth') ?></label>
                         <input type="color" class="picker" name="vars[arrows_not_related]" id="arrows_not_related" value="<?= e($vars["arrows_not_related"]); ?>" /><label for="arrows_not_related" class="picker-label"><?= I18N::translate('Related other than by birth') ?></label>

--- a/resources/views/MainPage/Appearance/DiagramType.phtml
+++ b/resources/views/MainPage/Appearance/DiagramType.phtml
@@ -10,7 +10,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('', 'Diagram type', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div class="row">
         <?php // Simple diagram type no longer exists, but we need to handle it if we find the setting in loaded settings
         MainPage::handleSimpleSettings($vars['diagram_type']); ?>

--- a/resources/views/MainPage/Appearance/GraphDirection.phtml
+++ b/resources/views/MainPage/Appearance/GraphDirection.phtml
@@ -10,6 +10,6 @@ use vendor\WebtreesModules\gvexport\MainPage;
 ?>
 
 <?= MainPage::addLabel('graph_dir', 'Graph direction', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <?= view('components/select', ['name' => 'vars[graph_dir]', 'id' => 'graph_dir', 'selected' => e($vars['graph_dir']), 'options' => MainPage::updateTranslations($settings["directions"])]) ?>
 </div>

--- a/resources/views/MainPage/Appearance/TileContents.phtml
+++ b/resources/views/MainPage/Appearance/TileContents.phtml
@@ -15,10 +15,10 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('', 'Tile contents', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div class="col-auto">
         <div onclick="Form.showHideSubgroup('url_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Page links'); ?></div>
-        <div id="url_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="url_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <input type="checkbox" name="vars[add_links]" id="add_links" value="add_links" <?= $vars["add_links"] ? 'checked' : '' ?>>
             <label for="add_links"><?= I18N::translate('Add URL to individuals and families') ?></label>
             <br>
@@ -27,7 +27,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
     <div class="col-auto">
         <div onclick="Form.showHideSubgroup('abbreviations_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Abbreviations'); ?></div>
-        <div id="abbreviations_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="abbreviations_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <div class="col-auto vspace-10">
                 <label for="use_abbr_name"><?= I18N::translate('Abbreviated names'); ?></label>
                 <?= view('components/select', ['name' => 'vars[use_abbr_name]', 'id' => 'use_abbr_name', 'selected' => I18N::digits($vars['use_abbr_name']), 'options' => MainPage::updateTranslations($settings["use_abbr_names"])]) ?>
@@ -44,7 +44,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
     <div class="col-auto">
         <div onclick="Form.showHideSubgroup('indi_details_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Information on individuals'); ?></div>
-        <div id="indi_details_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="indi_details_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <div class="col-sm-8">
                 <?php
                 /* Check if another module (e.g. vesta classic) is adding the XREF to
@@ -66,7 +66,7 @@ use Fisharebest\Webtrees\I18N;
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_birthdate', 'birth_date_subgroup');" name="vars[show_birthdate]" id="show_birthdate" value="show_birthdate" <?= $vars["show_birthdate"] ? 'checked' : '' ?>>
                 <label for='show_birthdate'><?= I18N::translate('Show birthdate'); ?></label>
-                <div id="birth_date_subgroup" class="setting_subgroup col-auto wt-page-options-value" <?= !$vars["show_birthdate"] ? 'style="display:none;"' : '' ?>>
+                <div id="birth_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_birthdate"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto mx-3">
                         <input type="radio" name="vars[birthdate_year_only]" id="bd_type_y" value="true" <?= $vars["birthdate_year_only"] ? 'checked' : '' ?>>
                         <label for="bd_type_y"><?= I18N::translate('Year') ?></label>
@@ -85,7 +85,7 @@ use Fisharebest\Webtrees\I18N;
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_death_date', 'death_date_subgroup');" name="vars[show_death_date]" id="show_death_date" value="show_death_date" <?= $vars["show_death_date"] ? 'checked' : '' ?>>
                 <label for='show_death_date'><?= I18N::translate('Show death date'); ?></label>
-                <div id="death_date_subgroup" class="setting_subgroup col-auto wt-page-options-value" <?= !$vars["show_death_date"] ? 'style="display:none;"' : '' ?>>
+                <div id="death_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_death_date"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto mx-3">
                         <input type="radio" name="vars[death_date_year_only]" id="dd_type_y" value="true" <?= $vars["death_date_year_only"] ? 'checked' : '' ?>>
                         <label for="dd_type_y"><?= I18N::translate('Year') ?></label>
@@ -109,7 +109,7 @@ use Fisharebest\Webtrees\I18N;
     </div>
     <div class="col-auto">
         <div onclick="Form.showHideSubgroup('fam_details_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Information on families'); ?></div>
-        <div id="fam_details_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="fam_details_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <div class="col-sm-8">
                 <input type="checkbox" name="vars[show_xref_families]" id="show_xref_families" value="show_xref_families" <?= $vars["show_xref_families"] ? 'checked' : '' ?>>
                 <label for='show_xref_families'><?= I18N::translate('Show family XREF'); ?></label>
@@ -117,7 +117,7 @@ use Fisharebest\Webtrees\I18N;
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_marriage_date', 'marriage_date_subgroup');" name="vars[show_marriage_date]" id="show_marriage_date" value="show_marriage_date" <?= $vars["show_marriage_date"] ? 'checked' : '' ?>>
                 <label for='show_marriage_date'><?= I18N::translate('Show marriage date'); ?></label>
-                <div id="marriage_date_subgroup" class="setting_subgroup col-auto wt-page-options-value" <?= !$vars["show_marriage_date"] ? 'style="display:none;"' : '' ?>>
+                <div id="marriage_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriage_date"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto mx-3">
                         <input type="radio" name="vars[marr_date_year_only]" id="md_type_y" value="true" <?= $vars["marr_date_year_only"] ? 'checked' : '' ?>>
                         <label for="md_type_y"><?= I18N::translate('Year') ?></label>

--- a/resources/views/MainPage/Appearance/TileDesign.phtml
+++ b/resources/views/MainPage/Appearance/TileDesign.phtml
@@ -20,13 +20,13 @@ use Fisharebest\Webtrees\Auth;
 ?>
 
 <?= MainPage::addLabel('', 'Tile design', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div onclick="Form.showHideSubgroup('shape_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Shape'); ?></div>
-    <div id="shape_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="shape_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="col-auto">
             <label for="indi_tile_shape"><?= I18N::translate('Individual tile shape') ?></label>
             <?= view('components/select', ['name' => 'vars[indi_tile_shape]', 'id' => 'indi_tile_shape', 'selected' => e($vars['indi_tile_shape']), 'options' => MainPage::updateTranslations($settings["indi_tile_shape_options"])]) ?>
-            <div id="shape_sex_subgroup" class="setting_subgroup col-auto wt-page-options-value fit-content margin-top" <?= !$admin && $vars["indi_tile_shape"] != Person::TILE_SHAPE_SEX ? 'style="display:none;"' : '' ?>>
+            <div id="shape_sex_subgroup" class="setting_subgroup col-auto options-panel-background fit-content margin-top" <?= !$admin && $vars["indi_tile_shape"] != Person::TILE_SHAPE_SEX ? 'style="display:none;"' : '' ?>>
                 <div>
                     <label for="shape_sex_male"><?= I18N::translate('Male') ?></label>
                     <?= view('components/select', ['name' => 'vars[shape_sex_male]', 'id' => 'shape_sex_male', 'selected' => e($vars['shape_sex_male']), 'options' => MainPage::updateTranslations($settings["indi_tile_shape_custom_options"])]) ?>
@@ -44,7 +44,7 @@ use Fisharebest\Webtrees\Auth;
                     <?= view('components/select', ['name' => 'vars[shape_sex_unknown]', 'id' => 'shape_sex_unknown', 'selected' => e($vars['shape_sex_unknown']), 'options' => MainPage::updateTranslations($settings["indi_tile_shape_custom_options"])]) ?>
                 </div>
             </div>
-            <div id="vitals_shape_subgroup" class="setting_subgroup col-auto wt-page-options-value fit-content margin-top" <?= !$admin && $vars["indi_tile_shape"] != Person::TILE_SHAPE_VITAL ? 'style="display:none;"' : '' ?>>
+            <div id="vitals_shape_subgroup" class="setting_subgroup col-auto options-panel-background fit-content margin-top" <?= !$admin && $vars["indi_tile_shape"] != Person::TILE_SHAPE_VITAL ? 'style="display:none;"' : '' ?>>
                 <label for="shape_vital_dead"><?= I18N::translate('Deceased') ?></label>
                 <?= view('components/select', ['name' => 'vars[shape_vital_dead]', 'id' => 'shape_vital_dead', 'selected' => e($vars['shape_vital_dead']), 'options' => MainPage::updateTranslations($settings["indi_tile_shape_custom_options"])]) ?>
                 <label for="shape_vital_living"><?= I18N::translate('Living') ?></label>
@@ -61,11 +61,11 @@ use Fisharebest\Webtrees\Auth;
         }
         if ($images_enabled) { ?>
         <div onclick="Form.showHideSubgroup('photos_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Photos'); ?></div>
-        <div id="photos_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="photos_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_photos', 'photos_enabled_subgroup');" name="vars[show_photos]" id="show_photos" value="show_photos" <?= $vars["show_photos"] ? 'checked' : '' ?>>
                 <label for="show_photos"><?= I18N::translate('Show photos') ?></label>
-                <div id="photos_enabled_subgroup" class="setting_subgroup col-auto wt-page-options-value" <?= !$admin && !$vars["show_photos"] ? 'style="display:none;"' : '' ?>>
+                <div id="photos_enabled_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$admin && !$vars["show_photos"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto">
                         <label for="photo_shape"><?= I18N::translate('Photo shape') ?></label>
                         <?= view('components/select', ['name' => 'vars[photo_shape]', 'id' => 'photo_shape', 'selected' => e($vars['photo_shape']), 'options' => MainPage::updateTranslations($settings["photo_shape_options"])]) ?>
@@ -85,7 +85,7 @@ use Fisharebest\Webtrees\Auth;
         </div>
         <?php } ?>
         <div onclick="Form.showHideSubgroup('colours_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Colours'); ?></div>
-        <div id="colours_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+        <div id="colours_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
             <div class="col-auto margin-bottom">
                 <label for="bg_col_type"><?= I18N::translate('Individual background colour') ?></label>
                 <?= view('components/select', ['name' => 'vars[bg_col_type]', 'id' => 'bg_col_type', 'selected' => e($vars['bg_col_type']), 'options' => MainPage::updateTranslations($settings["bg_col_type_options"])]) ?>
@@ -110,7 +110,7 @@ use Fisharebest\Webtrees\Auth;
             <div class="col-auto margin-bottom">
                 <input type="checkbox" name="vars[sharednote_col_enable]" onclick="Form.showHide(document.getElementById('subgroup_note_colour'),this.checked)" id="sharednote_col_enable" value="sharednote_col_enable" <?= $vars["sharednote_col_enable"] ? 'checked' : '' ?>><label for="sharednote_col_enable" class="check-list width-90pc"><?= I18N::translate('Style individuals based on shared note') ?></label>
 
-                <div id="subgroup_note_colour" class="setting_subgroup col-auto wt-page-options-value fit-content margin-top" <?= !$admin && $vars["sharednote_col_enable"] != "true" ? 'style="display:none;"' : '' ?>>
+                <div id="subgroup_note_colour" class="setting_subgroup col-auto options-panel-background fit-content margin-top" <?= !$admin && $vars["sharednote_col_enable"] != "true" ? 'style="display:none;"' : '' ?>>
                     <input type="color" class="picker" name="vars[sharednote_col_default]" id="sharednote_col_default" value="<?= e($vars["sharednote_col_default"]); ?>" /><label for="sharednote_col_default" class="picker-label"><?= I18N::translate('Default background colour for new items') ?>:</label>
                     <?php if (!$admin) { ?>
                     <label for="sharednote_col_add"><?= I18N::translate('Add shared note style') ?>:</label>
@@ -161,7 +161,7 @@ use Fisharebest\Webtrees\Auth;
             </div>
             <div class="col-auto padding-left-10">
                 <input type="checkbox" name="vars[highlight_start_indis]" onclick="toggleHighlightStartPersons(this.checked, <?= !$admin ? 'false' : 'true'; ?>)" id="highlight_start_indis" value="true" <?= $vars["highlight_start_indis"] ? 'checked' : '' ?>><label for="highlight_start_indis" class="check-list width-90pc"><?= I18N::translate('Show starting individuals in different colour') ?></label>
-                <div class="setting_subgroup col-auto wt-page-options-value" id="startcol_option"  <?= !$admin && $vars["highlight_start_indis"] ? 'style="display:none;"' : '' ?>>
+                <div class="setting_subgroup col-auto options-panel-background" id="startcol_option"  <?= !$admin && $vars["highlight_start_indis"] ? 'style="display:none;"' : '' ?>>
                     <input type="color" class="picker" name="vars[highlight_col]" id="highlight_col" value="<?= e($vars["highlight_col"]); ?>" /><label for="highlight_col" class="picker-label"><?= I18N::translate('Starting individuals background colour') ?></label>
                     <?php if (!$admin) { ?>
                         <label for="no_highlight_xref_list"><?= I18N::translate('Colour these individuals:'); ?></label><br>
@@ -174,7 +174,7 @@ use Fisharebest\Webtrees\Auth;
             </div>
             <div class="col-auto padding-left-10">
                 <input type="checkbox" name="vars[highlight_custom_indis]" onclick="Form.showHideMatchCheckbox('highlight_custom_indis', 'highlight_custom_option');" id="highlight_custom_indis" value="true" <?= $vars["highlight_custom_indis"] ? 'checked' : '' ?>><label for="highlight_custom_indis" class="check-list width-90pc"><?= I18N::translate('Show selected individuals in different colour') ?></label>
-                <div class="setting_subgroup col-auto wt-page-options-value" id="highlight_custom_option"  data-test="<?= $vars["highlight_custom_indis"]; ?>" <?= !$admin && !$vars["highlight_custom_indis"] ? 'style="display:none;"' : '' ?>>
+                <div class="setting_subgroup col-auto options-panel-background" id="highlight_custom_option"  data-test="<?= $vars["highlight_custom_indis"]; ?>" <?= !$admin && !$vars["highlight_custom_indis"] ? 'style="display:none;"' : '' ?>>
                     <input type="color" class="picker" name="vars[highlight_custom_col]" id="highlight_custom_col" value="<?= e($vars["highlight_custom_col"]); ?>" /><label for="highlight_custom_col" class="picker-label"><?= I18N::translate('Highlighted individuals background colour') ?></label>
                     <div class="input-group-append">
                         <label for="highlight_custom" class="picker-label"><?= I18N::translate('Highlighted individuals XREFs') ?></label>
@@ -192,7 +192,7 @@ use Fisharebest\Webtrees\Auth;
         </div>
     </div>
     <div onclick="Form.showHideSubgroup('font_subgroup', this)" class="pointer subgroup">→ <?= I18N::translate('Font'); ?></div>
-    <div id="font_subgroup" class="setting_subgroup col-auto wt-page-options-value" style="display: none">
+    <div id="font_subgroup" class="setting_subgroup col-auto options-panel-background" style="display: none">
         <div class="col-auto">
             <label for="typeface"><?= I18N::translate('Typeface') ?></label>
             <div class="col-auto">

--- a/resources/views/MainPage/Appearance/TileDesign/Subgroup.phtml
+++ b/resources/views/MainPage/Appearance/TileDesign/Subgroup.phtml
@@ -7,6 +7,6 @@
 
 ?>
 
-<div id="subgroup_<?= $view_options['group'] . '_' . $view_options['field']; ?>" class="setting_subgroup col-auto wt-page-options-value fit-content margin-top" <?= !$view_options['admin'] && $view_options['vars'][$view_options['select_id']] != $view_options['option_id'] ? 'style="display:none;"' : '' ?>>
+<div id="subgroup_<?= $view_options['group'] . '_' . $view_options['field']; ?>" class="setting_subgroup col-auto options-panel-background fit-content margin-top" <?= !$view_options['admin'] && $view_options['vars'][$view_options['select_id']] != $view_options['option_id'] ? 'style="display:none;"' : '' ?>>
     <?= view($view, $view_options + ['view_options' => $view_options]); ?>
 </div>

--- a/resources/views/MainPage/DebugPanel.phtml
+++ b/resources/views/MainPage/DebugPanel.phtml
@@ -11,13 +11,13 @@ use vendor\WebtreesModules\gvexport\Settings;
 
 <div class="row no-right-margin form-group">
     <?= MainPage::addLabel('enable_debug_mode', 'Debug mode', FALSE); ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <label for="enable_debug_mode"><?= I18N::translate('Enable debug mode') ?></label>
         <input type="checkbox" name="vars[enable_debug_mode]" id="enable_debug_mode" value="enable_debug_mode" <?= $vars["enable_debug_mode"] ? 'checked' : '' ?>><br>
         <button class="btn btn-outline-secondary" type="button" name="debug_view" onclick="return showHelp('enable_debug_mode');"><?= I18N::translate('View debug log') ?></button>
     </div>
     <?= MainPage::addLabel('enable_graphviz', 'Graphviz', FALSE); ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <label for="enable_graphviz"><?= I18N::translate('Use Graphviz on server') ?></label>
         <input type="checkbox" name="vars[enable_graphviz]" id="enable_graphviz" value="enable_graphviz" onclick="setGraphvizAvailable(this.value==='enable_graphviz');" <?= $vars["enable_graphviz"] && (new Settings())->getDefaultSettings()['graphviz_bin'] != "" ? 'checked' : '' ?> <?= (new Settings())->getDefaultSettings()['graphviz_bin'] == "" ? "disabled" : ""; ?>><br></div>
 </div>

--- a/resources/views/MainPage/GeneralSettings.phtml
+++ b/resources/views/MainPage/GeneralSettings.phtml
@@ -30,4 +30,4 @@ use vendor\WebtreesModules\gvexport\GVExport;
             <?= view($module->name() . '::MainPage/GeneralSettings/MessageHistory', ['admin' => $admin]); ?>
         </div>
     </div>
-    <a id="files-advanced-button" onclick="Form.toggleAdvanced(this, 'files-advanced')"><div class="wt-page-options-label advanced-settings-btn"><?= ($vars["show_adv_files"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_files"] ? ' ↑' : ' ↓'); ?></div></a>
+    <a id="files-advanced-button" onclick="Form.toggleAdvanced(this, 'files-advanced')"><div class="sidebar-labels advanced-settings-btn"><?= ($vars["show_adv_files"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_files"] ? ' ↑' : ' ↓'); ?></div></a>

--- a/resources/views/MainPage/GeneralSettings/BrowserRender.phtml
+++ b/resources/views/MainPage/GeneralSettings/BrowserRender.phtml
@@ -11,7 +11,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('auto_update', 'Browser render', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <input type="checkbox" <?php if (!$admin) echo 'onclick="toggleUpdateButton()"'; ?> name="vars[auto_update]" id="auto_update" value="auto_update" <?= $vars["auto_update"] ? 'checked' : '' ?>>
     <label for="auto_update"><?= I18N::translate('Auto-update') ?></label>
     <div class="col-auto vspace-10">

--- a/resources/views/MainPage/GeneralSettings/MessageHistory.phtml
+++ b/resources/views/MainPage/GeneralSettings/MessageHistory.phtml
@@ -9,6 +9,6 @@ use vendor\WebtreesModules\gvexport\MainPage;
 ?>
 
 <?= MainPage::addLabel('message_history', 'Message history', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <button class="btn btn-outline-secondary" type="button" name="message_history" onclick="return showHelp('message_history');"><?= I18N::translate('View message history') ?></button>
 </div>

--- a/resources/views/MainPage/GeneralSettings/OutputFile.phtml
+++ b/resources/views/MainPage/GeneralSettings/OutputFile.phtml
@@ -13,11 +13,11 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('', 'Output file', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <label for="output_type"><?= I18N::translate('Output file type') ?></label>
     <?= view('components/select', ['name' => 'vars[output_type]', 'id' => 'output_type', 'selected' => e($vars['output_type']), 'options' => $otypes]) ?>
     <small id="emailHelp" class="form-text text-muted"><?= $usegraphviz ? "" : I18N::translate('Options limited as Graphviz not installed on server') ?></small>
-    <div id="server_pdf_subgroup" class="setting_subgroup col-auto wt-page-options-value" <?= !($vars["output_type"] == 'pdf' || $vars["output_type"] == 'svg') || !$usegraphviz ? 'style="display:none;"' : '' ?>>
+    <div id="server_pdf_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !($vars["output_type"] == 'pdf' || $vars["output_type"] == 'svg') || !$usegraphviz ? 'style="display:none;"' : '' ?>>
         <div class="col-auto">
             <label for="photo_quality"><?= I18N::translate('Quality of JPG photos') ?></label>
             <?= view('components/select', ['name' => 'vars[photo_quality]', 'id' => 'photo_quality', 'selected' => e($vars['photo_quality']), 'options' => MainPage::updateTranslations($settings["photo_quality_options"])]) ?>

--- a/resources/views/MainPage/GeneralSettings/SaveSettings.phtml
+++ b/resources/views/MainPage/GeneralSettings/SaveSettings.phtml
@@ -11,7 +11,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('save_settings_name', 'Save settings', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <?php if (!$admin) { ?>
     <div id="settings_list">
 

--- a/resources/views/MainPage/GeneralSettings/SettingsFile.phtml
+++ b/resources/views/MainPage/GeneralSettings/SettingsFile.phtml
@@ -9,7 +9,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('', 'Settings file', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <label for="load_settings"><?= I18N::translate('Load settings from file') ?></label><br>
     <input id="load_settings" type="file" onchange="uploadSettingsFile(this)">
 </div>

--- a/resources/views/MainPage/PeopleToInclude.phtml
+++ b/resources/views/MainPage/PeopleToInclude.phtml
@@ -48,4 +48,4 @@ use vendor\WebtreesModules\gvexport\GVExport;
         <?= view($module->name() . '::MainPage/PeopleToInclude/TreatmentOfSourceIndividuals',['vars' => $vars, 'settings' => $settings, 'admin' => $admin]); ?>
     </div>
 </div>
-<a id="people-advanced-button" onclick="Form.toggleAdvanced(this, 'people-advanced')"><div class="wt-page-options-label advanced-settings-btn"><?= ($vars["show_adv_people"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_people"] ? ' ↑' : ' ↓'); ?></div></a>
+<a id="people-advanced-button" onclick="Form.toggleAdvanced(this, 'people-advanced')"><div class="sidebar-labels advanced-settings-btn"><?= ($vars["show_adv_people"] ? '↑ ' : '↓ ') . I18N::translate('Toggle advanced settings') . ($vars["show_adv_people"] ? ' ↑' : ' ↓'); ?></div></a>

--- a/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
+++ b/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
@@ -9,7 +9,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
  */
 ?>
 <?= MainPage::addLabel('', 'Connections to include', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div class="row">
         <div class="col-sm-6">
             <div class="align-middle-container">

--- a/resources/views/MainPage/PeopleToInclude/IncludeAnyoneRelatedTo.phtml
+++ b/resources/views/MainPage/PeopleToInclude/IncludeAnyoneRelatedTo.phtml
@@ -12,7 +12,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
 
 ?>
 <?= MainPage::addLabel('pid', 'Include anyone related to', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div id="indi_list">
 
     </div>

--- a/resources/views/MainPage/PeopleToInclude/ItemsInClippingsCart.phtml
+++ b/resources/views/MainPage/PeopleToInclude/ItemsInClippingsCart.phtml
@@ -10,12 +10,12 @@ use vendor\WebtreesModules\gvexport\MainPage;
 
 ?>
 <?= MainPage::addLabel('', 'Clippings cart', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <?php
         if (!$admin) {
             I18N::translate('You have items in the clippings cart, which can be used for the diagram instead of the below options.');
         } ?>
-    <div class="col-sm-8 wt-page-options-value">
+    <div class="col-sm-8 options-panel-background">
         <div class="row">
             <div class="col-auto mx-3">
                 <input type="radio" onclick="Form.toggleCart(true)" name="vars[use_cart]" id="usecart_yes" value="use_cart" <?= $vars["use_cart"] ? 'checked' : '' ?>>

--- a/resources/views/MainPage/PeopleToInclude/NonRelatives.phtml
+++ b/resources/views/MainPage/PeopleToInclude/NonRelatives.phtml
@@ -10,10 +10,10 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('mark_not_related', 'Non-relatives', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <input class="cart_toggle" onclick="Form.showHideMatchCheckbox('mark_not_related', 'mark_related_subgroup');" type="checkbox" name="vars[mark_not_related]" id="mark_not_related" value="mark_not_related" <?= $vars["mark_not_related"] ? 'checked' : '' ?>>
     <label class="check-list width-90pc" for="mark_not_related"><?= I18N::translate('Mark not blood-related people with different colour') ?></label>
-    <div id="mark_related_subgroup" class="setting_subgroup col-auto wt-page-options-value">
+    <div id="mark_related_subgroup" class="setting_subgroup col-auto options-panel-background">
         <input class="cart_toggle" type="checkbox" name="vars[faster_relation_check]" id="faster_relation_check" value="faster_relation_check" <?= $vars["faster_relation_check"] ? 'checked' : '' ?>>
         <label class="check-list width-90pc" for="faster_relation_check"><?= I18N::translate('Ignore unseen links to speed up relative check') ?></label>
     </div>

--- a/resources/views/MainPage/PeopleToInclude/StopProcessingOn.phtml
+++ b/resources/views/MainPage/PeopleToInclude/StopProcessingOn.phtml
@@ -13,7 +13,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <?= MainPage::addLabel('stop_xref_list', 'Stop processing on', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div id="stop_indi_list">
 
     </div>

--- a/resources/views/MainPage/PeopleToInclude/TreatmentOfSourceIndividuals.phtml
+++ b/resources/views/MainPage/PeopleToInclude/TreatmentOfSourceIndividuals.phtml
@@ -10,6 +10,6 @@ use vendor\WebtreesModules\gvexport\MainPage;
 ?>
 
 <?= MainPage::addLabel('url_xref_treatment', 'Treatment of source individuals', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <?= view('components/select', ['name' => 'vars[url_xref_treatment]', 'id' => 'url_xref_treatment', 'selected' => e($vars['url_xref_treatment']), 'options' => MainPage::updateTranslations($settings["url_xref_treatment_options"])]) ?>
 </div>

--- a/resources/views/MainPage/PeopleToInclude/XrefOfIncludedIndividuals.phtml
+++ b/resources/views/MainPage/PeopleToInclude/XrefOfIncludedIndividuals.phtml
@@ -8,7 +8,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
  */
 ?>
 <?= MainPage::addLabel('xref_list', 'XREFs of included individuals', !$admin); ?>
-<div class="col-sm-8 wt-page-options-value">
+<div class="col-sm-8 options-panel-background">
     <div class="input-group mt-1">
         <input type="text" class="form-control" name="vars[xref_list]" id="xref_list" value="<?= e($vars['xref_list']) ?>" onchange="refreshIndisFromXREFS(true)">
         <div class="input-group-append">

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -43,7 +43,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
     <?= $title ?>
 </h2>
 
-<form action="<?= $module->chartUrl($individual) ?>" method="post" class="wt-page-options sidebar d-print-none" id="gvexport">
+<form action="<?= $module->chartUrl($individual) ?>" method="post" class="sidebar d-print-none" id="gvexport">
     <div class="pull-right btn-hover">
         <a class="hide-form btn btn-secondary pointer"><i class="fa-solid fa-xmark"></i></a>
     </div>
@@ -59,7 +59,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
 
             <div class="row no-right-margin form-group">
                 <?= MainPage::addLabel('simple_settings_list', 'List of diagrams'); ?>
-                <div class="col-sm-8 wt-page-options-value">
+                <div class="col-sm-8 options-panel-background">
                     <select id="simple_settings_list" class="form-select">
                         <option value="-">-</option>
                     </select>

--- a/resources/views/settings.phtml
+++ b/resources/views/settings.phtml
@@ -39,7 +39,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
         <h2><?= I18N::translate('Settings for GVExport'); ?></h2>
         <div class="row form-group">
             <label class="col-sm-4 col-form-label"><?= I18N::translate('Administrator settings') ?></label>
-            <div class="col-sm-8 wt-page-options-value">
+            <div class="col-sm-8 options-panel-background">
                 <label for="filename"><?= I18N::translate('Download file name') ?>:</label>
                 <input class="form-control col-sm-6" type="text" name="vars[filename]" id="filename" value="<?= e($vars["filename"]) ?>">
                 <label for="mclimit"><?= I18N::translate('Graphviz MCLIMIT setting') ?>:</label>


### PR DESCRIPTION
Many colours in GVExport are hard coded, so this is an attempt to use the available CSS variables.

Some minor visual changes, but I've used Javascript to try to keep the default theme similar, and have added custom CSS to use the Primer theme better.

Resolves #505 