### PR TITLE
Add option to decide if similar events are used to present dates and places of birth and death

### DIFF
--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -143,6 +143,7 @@ class FormSubmission
         }
 
         $settings['show_marriage_place'] = isset($vars['show_marriage_place']);
+        $settings['use_alt_events'] = isset($vars['use_alt_events']);
         $settings['show_indi_sex'] = isset($vars['show_indi_sex']);
         $settings['show_xref_individuals'] = isset($vars['show_xref_individuals']);
         $settings['show_xref_families'] = isset($vars['show_xref_families']);

--- a/app/Person.php
+++ b/app/Person.php
@@ -102,6 +102,7 @@ class Person
         $out = '';
         $border_colour = $this->dot->settings["border_col"];    // Border colour of the INDI's box
         $death_place = "";
+        $birthplace = "";
         $i = $this->dot->getUpdatedPerson($pid);
         // Get the personal data
         if ($this->dot->settings["diagram_type"] == "combined" && (substr($pid, 0, 3) == "I_H" || substr($pid, 0, 3) == "I_W") || substr($pid, 0, 3) == "I_N") {
@@ -134,27 +135,60 @@ class Person
 
             // --- Birth date ---
             if ($this->dot->settings["show_birthdate"]) {
-                $birthdate = Dot::formatDate($i->getBirthDate(), $this->dot->settings["birthdate_year_only"],  $this->dot->settings["use_abbr_month"]);
-            } else {
+                if ($this->dot->settings["use_alt_events"]) {
+                      $date = $i->getBirthDate();
+                    } else {
+                        $dates = $i->getAllEventDates(['BIRT']);
+                        if ($dates !== []) {
+                            $date = $dates[0];
+                        } else {
+                            $date = new Date('');
+                        }
+                    }
+                    $birthdate = Dot::formatDate($date, $this->dot->settings["birthdate_year_only"],  $this->dot->settings["use_abbr_month"]);
+
+                } else {
                 $birthdate = "";
             }
 
             if ($this->dot->settings["show_birthplace"]) {
                 // Show birthplace
-                $birthplace = Dot::getAbbreviatedPlace($i->getBirthPlace()->gedcomName(), $this->dot->settings);
-            } else {
-                $birthplace = "";
+                if ($this->dot->settings["use_alt_events"]) {
+                    $birthplace = Dot::getAbbreviatedPlace($i->getBirthPlace()->gedcomName(), $this->dot->settings);
+                } else {
+                    $places = $i->getAllEventPlaces(['BIRT']);
+                    if ($places !== []) {
+                        $birthplace = $places[0]->gedcomName();
+                    }
+                }
             }
 
             // --- Death date ---
             if ($this->dot->settings["show_death_date"]) {
-                $death_date = Dot::formatDate($i->getDeathDate(), $this->dot->settings["death_date_year_only"],  $this->dot->settings["use_abbr_month"]);
+                if ($this->dot->settings["use_alt_events"]) {
+                    $date = $i->getDeathDate();
+                } else {
+                    $dates = $i->getAllEventDates(['DEAT']);
+                    if ($dates !== []) {
+                        $date = $dates[0];
+                    } else {
+                        $date = new Date('');
+                    }
+                }
+                $death_date = Dot::formatDate($date, $this->dot->settings["death_date_year_only"], $this->dot->settings["use_abbr_month"]);
             } else {
                 $death_date = "";
             }
             if ($this->dot->settings["show_death_place"]) {
                 // Show death place
-                $death_place = Dot::getAbbreviatedPlace($i->getDeathPlace()->gedcomName(), $this->dot->settings);
+                if ($this->dot->settings["use_alt_events"]) {
+                    $death_place = Dot::getAbbreviatedPlace($i->getDeathPlace()->gedcomName(), $this->dot->settings);
+                } else {
+                    $places = $i->getAllEventPlaces(['DEAT']);
+                    if ($places !== []) {
+                        $death_place = $places[0]->gedcomName();
+                    }
+                }
             }
             // --- Name ---
             $names = $i->getAllNames();

--- a/config.php
+++ b/config.php
@@ -29,6 +29,7 @@ return array(
 	'show_death_date' => true, // Whether to show death date  for individuals
 	'death_date_year_only' => false, // Whether to show just the year or the full GEDCOM date pf death
 	'show_death_place' => true, // Whether to show death date for individuals
+	'use_alt_events' => true, // Whether to use similar events if the birth or death place is not available (e.g. Christening or Burial)
 	'show_marriage_date' => true, // Whether to show marriage date on the family record
 	'marr_date_year_only' => false, // Whether to show just the year or the full GEDCOM date of marriage
 	'show_marriage_place' => true, // Whether to show the place of marriage on the family record

--- a/resources/views/MainPage/Appearance/TileContents.phtml
+++ b/resources/views/MainPage/Appearance/TileContents.phtml
@@ -61,11 +61,11 @@ use Fisharebest\Webtrees\I18N;
                 }
                 ?>
                 <input type="checkbox" name="vars[show_xref_individuals]" id="show_xref_individuals" value="show_xref_individuals" <?= $vars["show_xref_individuals"] || $overridePID ? 'checked' : '' ?>>
-                <label for='show_xref_individuals'><?= I18N::translate('Show individual XREF'); ?></label>
+                <label class="check-list" for='show_xref_individuals'><?= I18N::translate('Show individual XREF'); ?></label>
             </div>
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_birthdate', 'birth_date_subgroup');" name="vars[show_birthdate]" id="show_birthdate" value="show_birthdate" <?= $vars["show_birthdate"] ? 'checked' : '' ?>>
-                <label for='show_birthdate'><?= I18N::translate('Show birthdate'); ?></label>
+                <label class="check-list" for='show_birthdate'><?= I18N::translate('Show birthdate'); ?></label>
                 <div id="birth_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_birthdate"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto mx-3">
                         <input type="radio" name="vars[birthdate_year_only]" id="bd_type_y" value="true" <?= $vars["birthdate_year_only"] ? 'checked' : '' ?>>
@@ -79,12 +79,12 @@ use Fisharebest\Webtrees\I18N;
             </div>
             <div class="col-sm-8">
                 <input type="checkbox" name="vars[show_birthplace]" id="show_birthplace" value="show_birthplace" <?= $vars["show_birthplace"] ? 'checked' : '' ?>>
-                <label for='show_birthplace'><?= I18N::translate('Show birthplace'); ?></label>
+                <label class="check-list" for='show_birthplace'><?= I18N::translate('Show birthplace'); ?></label>
             </div>
 
             <div class="col-sm-8">
                 <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_death_date', 'death_date_subgroup');" name="vars[show_death_date]" id="show_death_date" value="show_death_date" <?= $vars["show_death_date"] ? 'checked' : '' ?>>
-                <label for='show_death_date'><?= I18N::translate('Show death date'); ?></label>
+                <label class="check-list" for='show_death_date'><?= I18N::translate('Show death date'); ?></label>
                 <div id="death_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_death_date"] ? 'style="display:none;"' : '' ?>>
                     <div class="col-auto mx-3">
                         <input type="radio" name="vars[death_date_year_only]" id="dd_type_y" value="true" <?= $vars["death_date_year_only"] ? 'checked' : '' ?>>
@@ -99,11 +99,16 @@ use Fisharebest\Webtrees\I18N;
 
             <div class="col-sm-8">
                 <input type="checkbox" name="vars[show_death_place]" id="show_death_place" value="show_death_place" <?= $vars["show_death_place"] ? 'checked' : '' ?>>
-                <label for='show_death_place'><?= I18N::translate('Show death place'); ?></label>
+                <label class="check-list" for='show_death_place'><?= I18N::translate('Show death place'); ?></label>
+            </div>
+
+            <div>
+                <input type="checkbox" name="vars[use_alt_events]" id="use_alt_events" value="use_alt_events" <?= $vars["use_alt_events"] ? 'checked' : '' ?>>
+                <label class="check-list width-90pc" for='use_alt_events'><?= I18N::translate('Use similar events if information not available'); ?></label>
             </div>
             <div class="col-sm-8">
                 <input type="checkbox" name="vars[show_indi_sex]" id="show_indi_sex" value="show_indi_sex" <?= $vars["show_indi_sex"] ? 'checked' : '' ?>>
-                <label for='show_indi_sex'><?= I18N::translate('Show sex of individuals'); ?></label>
+                <label class="check-list" for='show_indi_sex'><?= I18N::translate('Show sex of individuals'); ?></label>
             </div>
         </div>
     </div>

--- a/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
+++ b/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
@@ -92,6 +92,17 @@ $help = new Help();
 <p>
     <?= I18N::translate('Whether to show the place of death in the output. Also see option for abbreviating place names.'); ?>
 </p>
+<h5><?= I18N::translate('Use similar events if information not available'); ?></h5>
+<p>
+    <?= I18N::translate('When showing information about a birth or death, if the information is not available then webtrees will look for similar events and use the information from those events instead.'); ?>
+</p>
+<ul>
+    <li><?= I18N::translate('If a birth date or place is not recorded, webtrees will attempt to use the date or place of the christening or baptism if it exists.'); ?></li>
+    <li><?= I18N::translate('If a death date or place is not recorded, webtrees will attempt to use the date or place of the burial or cremation if it exists.'); ?></li>
+</ul>
+<p>
+    <?= I18N::translate('If you disable this option, GVExport will only use information from birth and death events, and not try to find missing information in similar events.'); ?>
+</p>
 <h5><?= I18N::translate('Show sex of individuals'); ?></h5>
 <p>
     <?= I18N::translate('Whether to print the sex of the individual on the individual&apos;s tile, e.g. &quot;Male&quot;'); ?>


### PR DESCRIPTION
Added new option "Use similar events if information not available" in Appearance->Tile contents->Information on individuals.

This option is enabled by default to keep current functionality, where we use webtrees functions to get the dates and places of birth and death.

Disabling this option now bypasses the webtrees functionality and directly checks for a BIRT or DEAT event, preventing christening, baptism, burial, or cremation dates and places from being used for births and deaths.

Closes #498 