### PR TITLE
Add limit to max levels

### DIFF
--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -73,6 +73,12 @@ class FormSubmission
             $settings['marriage_prefix'] = $vars["marriage_prefix"];
         }
 
+        foreach (Settings::USER_ROLES as $role) {
+            if (isset($vars['limit_levels_' . strtolower($role)])) {
+                $settings['limit_levels_' . strtolower($role)] = I18N::digits($vars['limit_levels_' . strtolower($role)]);
+            }
+        }
+
         $settings['mark_not_related'] = isset($vars['mark_not_related']);
         $settings['faster_relation_check'] = isset($vars['faster_relation_check']);
 

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -487,6 +487,7 @@ class Settings
             case 'border_col_type_options':
             case 'settings_sort_order_options':
             case 'click_action_indi_options':
+            case 'limit_levels':
                 return false;
             case 'show_debug_panel':
             case 'filename':

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -38,6 +38,7 @@ class Settings
     public const OPTION_BORDER_FAMILY = 320;
     public const OPTION_BORDER_VITAL_COLOUR = 330;
     public const OPTION_BORDER_AGE_COLOUR = 340;
+    public const USER_ROLES = ['Visitor', 'Member', 'Editor', 'Moderator', 'Manager'];
     const TREE_PREFIX = "_t";
     const USER_PREFIX = "_u";
     private array $settings_json_cache = [];
@@ -76,6 +77,7 @@ class Settings
         $this->defaultSettings['sharednote_col_data'] = '[]';
         $this->defaultSettings['updated_date'] = '';
         $this->defaultSettings['highlight_custom_json'] = '{}';
+        $this->defaultSettings['limit_levels'] = '0';
 
     }
 
@@ -187,6 +189,7 @@ class Settings
         if (!$settings['enable_graphviz'] && $settings['graphviz_bin'] != "") {
             $settings['graphviz_bin'] = "";
         }
+        $settings['limit_levels'] = $this->getLevelLimit($tree, $settings);
         return $settings;
     }
 
@@ -491,6 +494,11 @@ class Settings
             case 'birth_prefix':
             case 'death_prefix':
             case 'marriage_prefix':
+            case 'limit_levels_visitor':
+            case 'limit_levels_member':
+            case 'limit_levels_editor':
+            case 'limit_levels_moderator':
+            case 'limit_levels_manager':
                 return $context == self::CONTEXT_ADMIN;
             case 'show_diagram_panel':
                 return $context != self::CONTEXT_NAMED_SETTING;
@@ -815,5 +823,29 @@ class Settings
     {
         $userSettings = $this->loadUserSettings($module, $tree, $settings_id);
         return $userSettings['save_settings_name'];
+    }
+
+    /**
+     * Find the maximum number of ancestor or descendant levels this user is allowed
+     *
+     * @param $tree
+     * @param $settings
+     * @return string
+     */
+    private function getLevelLimit($tree, $settings)
+    {
+        if (Auth::isAdmin()) {
+            return '99';
+        } else if (Auth::isManager($tree)) {
+            return $settings['limit_levels_manager'];
+        } else if (Auth::isModerator($tree)) {
+            return $settings['limit_levels_moderator'];
+        } else if (Auth::isEditor($tree)) {
+            return $settings['limit_levels_editor'];
+        } else if (Auth::isMember($tree)) {
+            return $settings['limit_levels_member'];
+        } else {
+            return $settings['limit_levels_visitor'];
+        }
     }
 }

--- a/config.php
+++ b/config.php
@@ -124,6 +124,11 @@ return array(
 	'birth_prefix' => '*', // Text shown on chart before the birthdate
 	'death_prefix' => '†', // Text shown on chart before the death date
 	'marriage_prefix' => '∞', // Text shown on chart before the marriage date
+	'limit_levels_visitor' => '5', // How many ancestor or descendant levels a user with this privilege can select up to
+	'limit_levels_member' => '10', // How many ancestor or descendant levels a user with this privilege can select up to
+	'limit_levels_editor' => '15', // How many ancestor or descendant levels a user with this privilege can select up to
+	'limit_levels_moderator' => '20', // How many ancestor or descendant levels a user with this privilege can select up to
+	'limit_levels_manager' => '25', // How many ancestor or descendant levels a user with this privilege can select up to
     'save_settings_name' => '', // Default value for text field where name of settings can be entered
     'settings_sort_order' => 0, // Default value sorting the settings - default of 0 means the oldest items are first, new items go on the bottom of the list.
     'show_diagram_panel' => false, // If set to true, a "Saved diagrams" section is shown at the top, that lists settings saved using the feature to save multiple versions of settings

--- a/module.php
+++ b/module.php
@@ -256,7 +256,8 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
             try {
                 $temp_dir = $this->saveDOTFile($tree, $vars_data);
             } catch (Exception $e) {
-                return Registry::responseFactory()->response('Failed to generate file', StatusCodeInterface::STATUS_NOT_ACCEPTABLE);
+                // Remove comments around $e below to get a proper error message. Ensure full error is not showing for prod.
+                return Registry::responseFactory()->response('Failed to generate file' /* . $e */, StatusCodeInterface::STATUS_NOT_ACCEPTABLE);
             }
             // If browser mode, output dot instead of selected file
             $file_type = isset($_POST["browser"]) && $_POST["browser"] == "true" ? "dot" : $vars_data["output_type"];
@@ -349,7 +350,8 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
             $vars['temp_dir'] = $temp_dir;
         }
         $dot->setSettings($vars);
-
+        $dot->settings['ancestor_levels'] = min($vars['ancestor_levels'], $dot->settings['limit_levels']);
+        $dot->settings['descendant_levels'] = min($vars['descendant_levels'], $dot->settings['limit_levels']);
         $settings = new Settings();
         $settings->saveUserSettings($this, $tree,$dot->settings);
         // Get out DOT file

--- a/resources/css/gvexport.css
+++ b/resources/css/gvexport.css
@@ -267,8 +267,7 @@
 }
 
 .list_item_skinny {
-    width: 80%;
-    display: block;
+    width: 80% !important;
 }
 
 .list_item_content {

--- a/resources/javascript/MainPage/Form.js
+++ b/resources/javascript/MainPage/Form.js
@@ -531,10 +531,10 @@ const Form = {
                 newListItem.setAttribute("data-xref", xref);
                 newListItem.setAttribute("onclick", "UI.scrollToRecord('" + xref + "')");
                 const listItemIndi = document.createElement("span");
-                listItemIndi.innerHTML = contents + "<div class=\"saved-settings-ellipsis\" onclick=\"Form.indiList.removeItem(event, this.parentElement" + (colour === '' ? '' :  '.parentElement') + ", '" + otherXrefId + "')\"><a class='pointer'>×</a></div>";
+                listItemIndi.innerHTML = contents + "<div class=\"saved-settings-ellipsis\" onclick=\"Form.indiList.removeItem(event, this.parentElement.parentElement" + ", '" + otherXrefId + "')\"><a class='pointer'>×</a></div>";
                 newListItem.appendChild(listItemIndi);
                 if (colour !== '') {
-                    listItemIndi.setAttribute('class', 'list_item_skinny');
+                    listItemIndi.setAttribute('class', 'list_item_skinny list_item_content');
                     let picker = `<input type="color" class="highlight_picker" data-xref="${xref}" value="${colour}">`;
                     newListItem.innerHTML = newListItem.innerHTML + picker;
                     newListItem.querySelector('.highlight_picker')?.addEventListener('change', Form.indiList.updateHighlightColour);
@@ -562,6 +562,7 @@ const Form = {
         removeItem(e, element, xrefListId) {
             e.stopPropagation();
             let xref = element.getAttribute("data-xref").trim();
+            let list = document.getElementById(xrefListId);
             removeFromXrefList(xref, xrefListId);
             element.remove();
             if (xrefListId === 'xref_list') {
@@ -569,7 +570,6 @@ const Form = {
             }
             updateClearAll();
             if (xrefListId === 'highlight_custom_json') {
-                let list = document.getElementById(xrefListId);
                 let data = JSON.parse(list.value);
                 delete data[xref];
                 list.value = JSON.stringify(data);

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -327,7 +327,7 @@ function pageLoaded(Url) {
     document.addEventListener("mousedown", function(event) {
 
         // Hide diagram context menu if clicked off a tile
-        if (event.target.closest('.settings_ellipsis_menu_item') == null && event.target.parent.id !== 'menu-info') {
+        if (event.target.closest('.settings_ellipsis_menu_item') == null && event.target.parent && event.target.parent.id !== 'menu-info') {
             UI.contextMenu.clearContextMenu();
         }
     });

--- a/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
+++ b/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
@@ -18,7 +18,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
             </div>
             <div class="align-middle-container">
                 <label for="ancestor_levels" class="col-sm-6"><?= I18N::translate('Max levels') ?></label>
-                <input type="number" min="0" max="99" class="cart_toggle form-control max-level-box" size="3" name="vars[ancestor_levels]" id="ancestor_levels" value="<?= I18N::digits($vars["ancestor_levels"]); ?>">
+                <input type="number" min="0" max="<?= $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[ancestor_levels]" id="ancestor_levels" value="<?= I18N::digits($vars["ancestor_levels"]); ?>">
             </div>
         </div>
         <div class="col-sm-6">
@@ -28,7 +28,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
             </div>
             <div class="align-middle-container">
                 <label for="descendant_levels" class="col-sm-6"><?= I18N::translate('Max levels') ?></label>
-                <input type="number" min="0" max="99" class="cart_toggle form-control max-level-box" size="3" name="vars[descendant_levels]" id="descendant_levels"
+                <input type="number" min="0" max="<?= $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[descendant_levels]" id="descendant_levels"
                        value="<?= I18N::digits($vars["descendant_levels"]); ?>">
             </div>
         </div>

--- a/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
+++ b/resources/views/MainPage/PeopleToInclude/ConnectionsToInclude.phtml
@@ -18,7 +18,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
             </div>
             <div class="align-middle-container">
                 <label for="ancestor_levels" class="col-sm-6"><?= I18N::translate('Max levels') ?></label>
-                <input type="number" min="0" max="<?= $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[ancestor_levels]" id="ancestor_levels" value="<?= I18N::digits($vars["ancestor_levels"]); ?>">
+                <input type="number" min="0" max="<?= $admin ? '99' : $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[ancestor_levels]" id="ancestor_levels" value="<?= I18N::digits($vars["ancestor_levels"]); ?>">
             </div>
         </div>
         <div class="col-sm-6">
@@ -28,7 +28,7 @@ use vendor\WebtreesModules\gvexport\MainPage;
             </div>
             <div class="align-middle-container">
                 <label for="descendant_levels" class="col-sm-6"><?= I18N::translate('Max levels') ?></label>
-                <input type="number" min="0" max="<?= $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[descendant_levels]" id="descendant_levels"
+                <input type="number" min="0" max="<?= $admin ? '99' : $vars['limit_levels'] ?>" class="cart_toggle form-control max-level-box" size="3" name="vars[descendant_levels]" id="descendant_levels"
                        value="<?= I18N::digits($vars["descendant_levels"]); ?>">
             </div>
         </div>

--- a/resources/views/settings.phtml
+++ b/resources/views/settings.phtml
@@ -51,6 +51,20 @@ $usegraphviz = $vars['graphviz_bin'] != "";
                 <label for="marriage_prefix"><?= I18N::translate('Marriage date prefix') ?>:</label>
                 <input class="form-control col-sm-6" type="text" name="vars[marriage_prefix]" id="marriage_prefix" pattern="^[A-Za-z0-9_ .*+()^%$#@!†∞-]*$" title="<?= I18N::translate('Letters, numbers, spaces, or the following symbols: ') . "_.*+()^%$#@!†∞-"; ?>" value="<?= e($vars["marriage_prefix"]); ?>">
             </div>
+            <hr>
+            <label class="col-sm-4 col-form-label"><?= I18N::translate('Limit ancestor and descendant levels') ?></label>
+            <div class="col-sm-8 options-panel-background">
+                <?php
+                    foreach (Settings::USER_ROLES as $role) {
+                ?>
+                <div>
+                    <label for="limit_levels_<?= strtolower($role); ?>"><?= I18N::translate($role) ?>:</label>
+                    <input type="number" min="0" max="99" class="form-control max-level-box" size="3" name="vars[limit_levels_<?= strtolower($role); ?>]" id="limit_levels_<?= strtolower($role); ?>" value="<?= I18N::digits($vars["limit_levels_" . strtolower($role)]); ?>">
+                </div>
+                <?php
+                    }
+                ?>
+            </div>
         </div>
 
         <h2><?= I18N::translate('Default values for GVExport'); ?></h2>


### PR DESCRIPTION
As per #500, this pull request adds an admin setting to limit the size of the diagram that a user can set. This is intended to help reduce strain on the server, and can be set based on the user's role.

If the limit is 10, this means the user can set up to 10 levels for ancestors and additionally up to 10 levels for descendants (a total of 20 levels).

The default settings are reasonably high, which should mean existing users shouldn't have an issue. You can change the settings in the control panel.

The default settings are:
Visitor: 5
Member: 10
Editor: 15
Moderator: 20
Manager: 25

Admins have a limit of 99 which is the existing limit, however this is now enforced in the backend not only in the website.

Note that we do not have admin help pages, so this is not explained in any detail within GVExport. I will update the wiki with some info.

Closes #500 