### PR TITLE
Restore line wrap to start and stop individuals list

### DIFF
--- a/resources/css/gvexport.css
+++ b/resources/css/gvexport.css
@@ -258,24 +258,16 @@
     display: flex;
 }
 
-.indi_list_item {
-    min-height: 42px;
-    line-height: 36px;
+.list-item-highlight {
+    width: 80%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.list_item_skinny {
-    width: 80% !important;
+    min-height: 40px;
 }
 
 .list_item_content {
     width: 95%;
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .options-panel-background {

--- a/resources/javascript/MainPage/Form.js
+++ b/resources/javascript/MainPage/Form.js
@@ -534,7 +534,7 @@ const Form = {
                 listItemIndi.innerHTML = contents + "<div class=\"saved-settings-ellipsis\" onclick=\"Form.indiList.removeItem(event, this.parentElement.parentElement" + ", '" + otherXrefId + "')\"><a class='pointer'>×</a></div>";
                 newListItem.appendChild(listItemIndi);
                 if (colour !== '') {
-                    listItemIndi.setAttribute('class', 'list_item_skinny list_item_content');
+                    listItemIndi.setAttribute('class', 'list-item-highlight');
                     let picker = `<input type="color" class="highlight_picker" data-xref="${xref}" value="${colour}">`;
                     newListItem.innerHTML = newListItem.innerHTML + picker;
                     newListItem.querySelector('.highlight_picker')?.addEventListener('change', Form.indiList.updateHighlightColour);


### PR DESCRIPTION
Undo a change that cut individuals names short in the lists of individuals in the settings, and returned to previous approach of having the name wrap to the next line. Highlighted individuals will still be cut off due to limited space available.

As per https://github.com/Neriderc/GVExport/pull/509#issuecomment-2444067793