### PR TITLE
Fix max levels defaulting to 0 on reset

### DIFF
--- a/app/Settings.php
+++ b/app/Settings.php
@@ -47,7 +47,7 @@ class Settings
     /**
      * Settings instance always starts with default settings
      */
-    public function __construct(){
+    public function __construct($tree = null){
         // Load settings from config file
         $this->defaultSettings = include dirname(__FILE__) . "/../config.php";
         // Add options lists
@@ -78,8 +78,7 @@ class Settings
         $this->defaultSettings['sharednote_col_data'] = '[]';
         $this->defaultSettings['updated_date'] = '';
         $this->defaultSettings['highlight_custom_json'] = '{}';
-        $this->defaultSettings['limit_levels'] = '0';
-
+        $this->defaultSettings['limit_levels'] = ($tree ? $this->getLevelLimit($tree, $this->defaultSettings) : '0');
     }
 
     /**
@@ -836,7 +835,7 @@ class Settings
      * @param $settings
      * @return string
      */
-    private function getLevelLimit($tree, $settings)
+    private function getLevelLimit($tree, $settings): string
     {
         if (Auth::isAdmin()) {
             return '99';

--- a/module.php
+++ b/module.php
@@ -184,8 +184,8 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
             $xref = $tree->getUserPreference(Auth::user(), UserInterface::PREF_TREE_ACCOUNT_XREF);
         }
         $individual = $this->getIndividual($tree, $tree->significantIndividual(Auth::user(), $xref)->xref());
-		$userDefaultVars = (new Settings())->getAdminSettings($this);
-        $settings = new Settings();
+		$userDefaultVars = (new Settings($tree))->getAdminSettings($this);
+        $settings = new Settings($tree);
         $userDefaultVars['first_render'] = true;
         if (isset($_REQUEST['reset'])){
             if (!$userDefaultVars['enable_graphviz'] && $userDefaultVars['graphviz_bin'] != "") {


### PR DESCRIPTION
When resetting user settings, the maximum level of ancestors/descendants was defaulting to 0. Fixes #518