### PR TITLE
Add download message

### DIFF
--- a/app/ApiHandler.php
+++ b/app/ApiHandler.php
@@ -98,6 +98,9 @@ class ApiHandler
                 case "get_shared_note_form":
                     $this->getSharedNoteForm();
                     break;
+                case "get_record_count":
+                    $this->getRecordCount();
+                    break;
                 default:
                     $this->response_data['success'] = false;
                     $this->response_data['json'] = $this->json_data;
@@ -180,7 +183,7 @@ class ApiHandler
     {
         if (isset($this->json['settings_id']) && (ctype_alnum((string) $this->json['settings_id']) || in_array($this->json['settings_id'], [Settings::ID_ALL_SETTINGS, Settings::ID_MAIN_SETTINGS]))) {
             $settings = new Settings();
-            // Treat loggged out users special if requesting ID_MAIN_SETTINGS
+            // Treat logged-out users special if requesting ID_MAIN_SETTINGS
             if ($this->json['settings_id'] == Settings::ID_MAIN_SETTINGS && Auth::user()->id() == Settings::GUEST_USER_ID) {
                 $vars = Validator::parsedBody($this->request)->array('vars');
                 $form = new FormSubmission();
@@ -417,5 +420,11 @@ class ApiHandler
         $vars = Validator::parsedBody($this->request)->array('vars');
         $this->response_data['success'] = true;
         $this->response_data['response'] = view($this->module->name() . '::MainPage/Appearance/TileDesign/SharedNote', ['vars' => $vars, 'tree' => $this->tree, 'module' => $this->module]);
+    }
+
+    private function getRecordCount()
+    {
+        $this->response_data['success'] = true;
+        $this->response_data['response'] = Settings::loadRecordCount($this->json['token']);
     }
 }

--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -20,6 +20,12 @@ class FormSubmission
     public function load($vars, $module): array
     {
         $settings = [];
+
+        if (isset($vars["time_token"]) && $this->isNameStringValid($vars["time_token"])) {
+            $settings['time_token'] = $vars["time_token"];
+        } else {
+            $settings['time_token'] = '';
+        }
         // INDI id
         if (!empty($vars["xref_list"]) && $this->isXrefListValid($vars["xref_list"])) {
             $settings['xref_list'] = $vars["xref_list"];

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -7,6 +7,8 @@ use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Http\Exceptions\HttpBadRequestException;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\GuestUser;
+
 
 /**
  * Represents the diagram settings, regardless of context (user, admin, default)
@@ -25,6 +27,7 @@ class Settings
     public const PREFERENCE_PREFIX = "GVE";
     public const SETTINGS_LIST_PREFERENCE_NAME = "_id_list";
     public const SAVED_SETTINGS_LIST_PREFERENCE_NAME = "_shared_settings_list";
+    const RECORD_COUNT_PREFERENCE_NAME = 'RECORD_COUNT';
     public const OPTION_STRIPE_NONE = 100;
     public const OPTION_STRIPE_SEX_COLOUR = 110;
     public const OPTION_STRIPE_VITAL_COLOUR = 120;
@@ -489,6 +492,7 @@ class Settings
             case 'click_action_indi_options':
             case 'arrow_style_options':
             case 'limit_levels':
+            case 'time_token':
                 return false;
             case 'show_debug_panel':
             case 'filename':
@@ -850,5 +854,48 @@ class Settings
         } else {
             return $settings['limit_levels_visitor'];
         }
+    }
+
+    /**
+     * Saves record count of diagram to session storage
+     *
+     * @param string $token Token used by front end to check record has been updated
+     * @param int $indis
+     * @param int $fams
+     * @return void
+     */
+    public function updateRecordCount(string $token, int $indis, int $fams)
+    {
+        $data = json_encode([
+            'time_token' => $token,
+            'indis' => $indis,
+            'fams' => $fams
+        ]);
+        $_SESSION[Settings::PREFERENCE_PREFIX . '_' . Settings::RECORD_COUNT_PREFERENCE_NAME] = $data;
+    }
+
+    /**
+     * Loads record count of diagram from session storage
+     *
+     * @param $token
+     * @return string
+     */
+    static public function loadRecordCount($token): string
+    {
+        $defaults = [
+            'time_token' => '',
+            'indis' => -1,
+            'fams' => -1
+        ];
+
+        $records = $_SESSION[Settings::PREFERENCE_PREFIX . '_' . Settings::RECORD_COUNT_PREFERENCE_NAME] ?? null;
+
+        $decoded = $records ? json_decode($records, true) : null;
+
+        if ($decoded && isset($decoded['time_token']) && $decoded['time_token'] === $token) {
+            return $records;
+        }
+
+        return json_encode($defaults);
     }
 }

--- a/module.php
+++ b/module.php
@@ -370,6 +370,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
         } else {
             $r = $out;
         }
+        $settings->updateRecordCount($dot->settings['time_token'], sizeof($dot->individuals), sizeof($dot->families));
         return $r;
     }
 

--- a/resources/javascript/MainPage/Data.js
+++ b/resources/javascript/MainPage/Data.js
@@ -66,6 +66,19 @@ const Data = {
         return Data.callAPI(request);
     },
 
+    /**
+     * Sends API request to retrieve record count
+     *
+     * @returns {Promise<unknown>}
+     */
+    getResourceCount(token) {
+        let request = {
+            "type": REQUEST_TYPE_GET_RECORD_COUNT,
+            "token": token,
+        };
+        return Data.callAPI(request);
+    },
+
     decodeHTML(html) {
         const textarea = document.createElement('textarea');
         textarea.innerHTML = html;

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -15,6 +15,7 @@ const REQUEST_TYPE_ADD_MY_FAVORITE = "add_my_favorite";
 const REQUEST_TYPE_ADD_TREE_FAVORITE = "add_tree_favorite";
 const REQUEST_TYPE_GET_HELP = "get_help";
 const REQUEST_TYPE_GET_SHARED_NOTE_FORM = "get_shared_note_form";
+const REQUEST_TYPE_GET_RECORD_COUNT = "get_record_count";
 let treeName = null;
 let loggedIn = null;
 let xrefList = [];
@@ -35,7 +36,7 @@ function loadURLXref(Url) {
                 let startValue = el.value;
                 Form.indiList.addIndiToList(xref);
                 if (url_xref_treatment === 'default' && xrefs.length === 1 ) {
-                    setTimeout(function () {UI.showToast(TRANSLATE['Source individual has replaced existing individual'].replace('%s', xrefs.length.toString()))}, 100);
+                    setTimeout(function () {UI.showToast(TRANSLATE['Source individual has replaced existing individual'])}, 100);
                 } else if (startValue !== el.value && (url_xref_treatment === 'default' || url_xref_treatment === 'add')) {
                     setTimeout(function () {UI.showToast(TRANSLATE['One new source individual added to %s existing individuals'].replace('%s', xrefs.length.toString()))}, 100);
                 }

--- a/resources/views/MainPage/Translations.phtml
+++ b/resources/views/MainPage/Translations.phtml
@@ -34,12 +34,13 @@ use Fisharebest\Webtrees\I18N;
     "Enter new setting name":"<?= I18N::translate('Enter new setting name'); ?>",
     "Rename":"<?= I18N::translate('Rename'); ?>",
     "No styles set based on shared notes.":"<?= I18N::translate('No styles set based on shared notes.'); ?>",
-    "%s shared note styles saved.":"<?= I18N::translate('%s shared note styles saved.', '%s'); ?>",
+    "%s shared note styles saved.":"<?= I18N::translate('%s shared note styles saved.', '%s'); ?>", // Javascript used to replace %s later
     "Add individual to list of starting individuals":"<?= I18N::translate('Add individual to list of starting individuals'); ?>",
     "Open individual's page":"<?= I18N::translate('Open individual\'s page'); ?>",
     "Replace starting individuals with this individual":"<?= I18N::translate('Replace starting individuals with this individual'); ?>",
     "Add this individual to the list of stopping individuals":"<?= I18N::translate('Add this individual to the list of stopping individuals'); ?>",
     "Replace stopping individuals with this individual":"<?= I18N::translate('Replace stopping individuals with this individual'); ?>",
     "Add to list of individuals to highlight":"<?= I18N::translate('Add to list of individuals to highlight'); ?>",
+    "Downloaded diagram with %s individuals and %s families.":"<?= I18N::translate('Downloaded diagram with %s individuals and %s families.', '%s', '%s'); ?>", // Javascript used to replace %s later
     };
 </script>

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -52,6 +52,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
 
         <?= csrf_field() ?>
 
+        <input type="hidden" id="time_token" name="vars[time_token]" value="">
         <div id="saved_diagrams_panel" <?php if (!$vars["show_diagram_panel"]) echo 'style="display: none"'; ?>>
             <div class="d-flex">
                 <h3><?= I18N::translate('Saved diagrams') ?></h3>
@@ -153,7 +154,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
             <div id="diagram_search_box_container" style="display: none"><?= view('components/select-individual', ['name' => 'diagram_search_box', 'id' => 'diagram_search_box', 'tree' => $tree, 'individual' => "", 'required'=>false]); ?></div>
         </div>
     </div>
-    <div id="context_menu">
+    <div id="context_menu" style="display: none">
         <span id="menu-info">
             <?= MainPage::addInfoButton('Context menu when individual clicked'); ?>
         </span>
@@ -217,7 +218,56 @@ $usegraphviz = $vars['graphviz_bin'] != "";
                 e.preventDefault();
             }
         }
+        let timeToken = crypto?.randomUUID?.() || (Date.now()).toString(16);
+
+        document.getElementById('time_token').value = timeToken;
+        setTimeout(() => { getResourceCountWithMyToken(timeToken)}, 500);
     });
+
+    /**
+     * Send request to server to get the number of individuals and families from the generated diagram
+     *
+     * @param myToken A time based token used to check that the information on record counts is from the same request we sent to the server
+     * @param callCount Keeps track of retries. If the server never gets updated to our token (maybe multiple requests messed this up), then we eventually give up.
+     */
+    function getResourceCountWithMyToken(myToken, callCount = 0) {
+
+        const MAX_RETRIES = 50;
+        const RETRY_DELAY = 500;
+        if (callCount >= MAX_RETRIES) {
+            console.log('Max retries reached for time token');
+            return;
+        }
+
+        if (myToken === '') {
+            retry(myToken, callCount);
+        }
+
+        Data.getResourceCount(myToken).then((response) => {
+            let obj;
+            try {
+                obj = JSON.parse(response);
+                if (obj['time_token'] === myToken) {
+                    let indis = obj['indis'];
+                    let fams = obj['fams'];
+                    if ('indis' in obj && 'fams' in obj) {
+                        UI.showToast(TRANSLATE['Downloaded diagram with %s individuals and %s families.'].replace('%s', indis).replace('%s', fams))
+                    }
+                } else {
+                    retry(myToken, callCount);
+                }
+            } catch (e) {
+                console.log('Failed to fetch resource counts: ' + e);
+                retry(myToken, callCount);
+            }
+        });
+
+        function retry(myToken, callCount) {
+            setTimeout(() => {
+                getResourceCountWithMyToken(myToken, callCount);
+            }, RETRY_DELAY);
+        }
+    }
 
     function updateRender(scrollX = null, scrollY = null, zoom = null, xref = null) {
         // Don't overwrite browser settings with default settings


### PR DESCRIPTION
Here is the replacement attempt at this. Added message when downloading to say how many individuals and families in generated diagram.

This does not work when you are generating SVG from the browser, because this option simply saves what you see into a file. All other options contact the server when generating (even if you don't have Graphviz on the server), and so this works with everything else (including SVG when generated on the server).

This closes #526, which also has some more information about the approach.

Basically I generate a UUID (or time based token if UUID is not available since this requires secure connection to site). Then I send this UUID with the diagram settings. The page then starts sending requests to the server with the UUID to check session storage for the counts stored there. Once the diagram is generated the counts are stored in session storage, and the page requests will succeed once this happens. Then the request retrieves the numbers and shows the message. 

This approach means it works for both logged out and logged in users without anything special.

Tries up to 50 times half a second apart, so will stop trying after 25 seconds or so. If the diagram takes longer than this to generate, then you won't see a message. If this isn't long enough then feel free to let me know and we can change it.