### PR TITLE
City only abbreviation

### DIFF
--- a/app/Dot.php
+++ b/app/Dot.php
@@ -1491,53 +1491,62 @@ class Dot {
         // If chose no abbreviating, then return string untouched
         if ($settings["use_abbr_place"] == 0 /* Full place name */) {
             return $place_long;
-        } else {
-            // Cut the place name up into pieces using the commas
-            $place_chunks = explode(",", $place_long);
-            $place = "";
-            $chunk_count = count($place_chunks);
-            // Add city to out return string as we always keep this
-            if (!empty($place_chunks[0])) {
-                $place .= trim($place_chunks[0]);
+        }
+
+        // Cut the place name up into pieces using the commas
+        $place_chunks = explode(",", $place_long);
+        $place = "";
+        $chunk_count = count($place_chunks);
+
+        // Add city to our return string as we always keep this
+        if (!empty($place_chunks[0])) {
+            $place .= trim($place_chunks[0]);
+
+            if ($settings["use_abbr_place"] == 5 /* City only */) {
+                return $place;
             }
-            // Chose to keep just the first and last sections
-            if ($settings["use_abbr_place"] == 10 /* City and Country */) {
-                if (!empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
-                    if (!empty($place)) {
-                        $place .= ", ";
-                    }
-                    $place .= trim($place_chunks[$chunk_count - 1]);
-                }
-            } else {
-                /* Otherwise, we have chosen one of the ISO code options */
-                switch ($settings["use_abbr_place"]) {
-                    case 20: //City and 2-Letter ISO Country Code
-                        $code = "iso2";
-                        break;
-                    case 30: //City and 3-Letter ISO Country Code
-                        $code = "iso3";
-                        break;
-                    default:
-                        return $place_long;
-                }
-                /* It's possible the place name string was blank, meaning our return variable is
-                       still blank. We don't want to add a comma if that's the case. */
-                if (!empty($place) && !empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
+        }
+
+        // Chose to keep just the first and last sections
+        if ($settings["use_abbr_place"] == 10 /* City and Country */) {
+            if (!empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
+                if (!empty($place)) {
                     $place .= ", ";
                 }
-                /* Look up our country in the array of country names.
-                   It must be an exact match, or it won't be abbreviated to the country code. */
-                if (isset($settings["countries"][$code][strtolower(trim($place_chunks[$chunk_count - 1]))])) {
-                    $place .= $settings["countries"][$code][strtolower(trim($place_chunks[$chunk_count - 1]))];
-                } else {
-                    // We didn't find out country in the abbreviation list, so just add the full country name
-                    if (!empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
-                        $place .= trim($place_chunks[$chunk_count - 1]);
-                    }
-                }
+                $place .= trim($place_chunks[$chunk_count - 1]);
+                return $place;
             }
-            return $place;
         }
+
+        /* Otherwise, we have chosen one of the ISO code options */
+        switch ($settings["use_abbr_place"]) {
+            case 20: //City and 2-Letter ISO Country Code
+                $code = "iso2";
+                break;
+            case 30: //City and 3-Letter ISO Country Code
+                $code = "iso3";
+                break;
+            default:
+                return $place_long;
+        }
+        
+        /* It's possible the place name string was blank, meaning our return variable is
+               still blank. We don't want to add a comma if that's the case. */
+        if (!empty($place) && !empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
+            $place .= ", ";
+        }
+
+        /* Look up our country in the array of country names.
+           It must be an exact match, or it won't be abbreviated to the country code. */
+        if (isset($settings["countries"][$code][strtolower(trim($place_chunks[$chunk_count - 1]))])) {
+            $place .= $settings["countries"][$code][strtolower(trim($place_chunks[$chunk_count - 1]))];
+        } else {
+            // We didn't find country in the abbreviation list, so just add the full country name
+            if (!empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {
+                $place .= trim($place_chunks[$chunk_count - 1]);
+            }
+        }
+        return $place;
     }
 
     /**

--- a/app/Dot.php
+++ b/app/Dot.php
@@ -1529,7 +1529,7 @@ class Dot {
             default:
                 return $place_long;
         }
-        
+
         /* It's possible the place name string was blank, meaning our return variable is
                still blank. We don't want to add a comma if that's the case. */
         if (!empty($place) && !empty($place_chunks[$chunk_count - 1]) && ($chunk_count > 1)) {

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -61,7 +61,7 @@ class Settings
         $this->defaultSettings['url_xref_treatment_options']['add'] = "Add to list";
         $this->defaultSettings['url_xref_treatment_options']['nothing'] = "Don't add to list";
         $this->defaultSettings['url_xref_treatment_options']['overwrite'] = "Overwrite";
-        $this->defaultSettings['use_abbr_places'] = [0 => "Full place name", 10 => "City and country" ,  20 => "City and 2 letter ISO country code", 30 => "City and 3 letter ISO country code"];
+        $this->defaultSettings['use_abbr_places'] = [0 => "Full place name", 5 => "City only" ,  10 => "City and country" ,  20 => "City and 2 letter ISO country code", 30 => "City and 3 letter ISO country code"];
         $this->defaultSettings['use_abbr_names'] = [0 => "Full name", 10 => "Given and surnames", 20 => "Given names" , 30 => "First given name only", 80 => "Preferred given name and surname", 40 => "Surnames", 50 => "Initials only", 60 => "Given name initials and surname", 70 => "Don't show names"];
         $this->defaultSettings['photo_shape_options'] = [Person::SHAPE_NONE => "No change", Person::SHAPE_OVAL => "Oval", Person::SHAPE_CIRCLE => "Circle" , Person::SHAPE_SQUARE => "Square", Person::SHAPE_ROUNDED_RECT => "Rounded rectangle", Person::SHAPE_ROUNDED_SQUARE => "Rounded square"];
         $this->defaultSettings['photo_quality_options'] = [0 => "Lowest", 20 => "Low", 50 => "Medium" , 75 => "High", 100 => "Highest"];

--- a/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
+++ b/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
@@ -53,8 +53,11 @@ $help = new Help();
     <?= I18N::translate('There are several options to shorten place names (for place of birth, place of marriage, place of death).'); ?>
 </p>
 <ul>
-    <li><?= I18N::translate('Full place name'); ?> - <?= I18N::translate('the place name is printed in full.'); ?></li>
-    <li><?= I18N::translate('City and country'); ?> - <?= I18N::translate('the first and last section of the place name is used, using commas to split the sections. For example, &quot;London, England, United Kingdom&quot; would be shortened to &quot;London, United Kingdom&quot;'); ?>
+    <li><?= I18N::translate('Full place name'); ?> - <?= I18N::translate('the place name is printed in full.'); ?>
+    </li>
+    <li><?= I18N::translate('City only'); ?> - <?= I18N::translate('only the first section of the place name is used, up to the first comma. For example, &quot;London, England, United Kingdom&quot; would be shortened to &quot;London&quot;'); ?>.
+    </li>
+    <li><?= I18N::translate('City and country'); ?> - <?= I18N::translate('the first and last section of the place name is used, using commas to split the sections. For example, &quot;London, England, United Kingdom&quot; would be shortened to &quot;London, United Kingdom&quot;'); ?>.
     </li>
     <li><?= I18N::translate('City and 2 letter ISO country code'); ?> - <?= I18N::translate('the first and last section of the place name is used, using commas to split the sections. The country is then converted to the ISO3166-1-Alpha-2 country code. <br>For example, &quot;Calgary, Alberta, Canada&quot; would be shortened to &quot;Calgary, CA&quot;'); ?>
     </li>


### PR DESCRIPTION
Added new option to place name abbreviations, to only show the city (i.e. just the part up to the first comma).

Partly addresses #515 