### PR TITLE
Fix loading xref from url

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -257,13 +257,14 @@ function pageLoaded(Url) {
                     }
                 })
             }
+
+            loadURLXref(Url);
+            refreshIndisFromXREFS(false);
         });
     }
 
     TOMSELECT_URL = document.getElementById('pid').getAttribute("data-wt-url") + "&query=";
-    loadURLXref(Url);
     loadUrlToken(Url);
-    refreshIndisFromXREFS(false);
     loadSettingsDetails();
     // Remove reset parameter from URL when page loaded, to prevent
     // further resets when page reloaded


### PR DESCRIPTION
Fixed issue where the xref in the URL was not loaded into the settings if the user was logged out, due to a timing issue.

Fixed #547 