### PR TITLE
Fix url xref

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -243,29 +243,24 @@ function showGraphvizUnsupportedMessage() {
 }
 
 // This function is run when the page is loaded
-function pageLoaded(Url) {
-
-    // Load settings for logged out user
+async function pageLoaded(Url) {
     if (firstRender) {
-        isUserLoggedIn().then((loggedIn) => {
-            if (!loggedIn) {
-                Data.storeSettings.getSettingsClient(ID_MAIN_SETTINGS).then((obj) => {
-                    if (obj !== null) {
-                        Form.settings.load(JSON.stringify(obj));
-                    } else {
-                        firstRender = false;
-                    }
-                })
+        const loggedIn = await isUserLoggedIn();
+        if (!loggedIn) {
+            const settings = await Data.storeSettings.getSettingsClient(ID_MAIN_SETTINGS);
+            if (settings !== null) {
+                Form.settings.load(JSON.stringify(settings));
+            } else {
+                firstRender = false;
             }
-
-            loadURLXref(Url);
-            refreshIndisFromXREFS(false);
-        });
+        }
     }
 
     TOMSELECT_URL = document.getElementById('pid').getAttribute("data-wt-url") + "&query=";
     loadUrlToken(Url);
     loadSettingsDetails();
+    loadURLXref(Url);
+    refreshIndisFromXREFS(false);
     // Remove reset parameter from URL when page loaded, to prevent
     // further resets when page reloaded
     Url.removeURLParameter("reset");

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -56,6 +56,8 @@ function stopIndiSelectChanged() {
 }
 
 function loadXrefList(url, xrefListId, indiListId) {
+    if (url === '') return false;
+
     let xrefListEl = document.getElementById(xrefListId);
     let xref_list = xrefListEl.value.trim();
     xrefListEl.value = xref_list;


### PR DESCRIPTION
Second attempt at fixing #547 

This pull request changes asynchronous request to retrieve settings from browser storage to use await so that loading XREF from URL is not overwritten by settings loaded from browser storage.

Additionally resolves a minor issue with an error being logged to console on page load, and also resolves what may have been an existing issue where starting indi list isn't properly set when user settings are reset.