### PR TITLE
Fix issue using PDF

### DIFF
--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -166,7 +166,7 @@ $usegraphviz = $vars['graphviz_bin'] != "";
 <script src="<?= $module->assetUrl('javascript/MainPage/UI.js'); ?>"></script>
 <script src="<?= $module->assetUrl('javascript/MainPage/Form.js'); ?>"></script>
 <script src="<?= $module->assetUrl('javascript/MainPage/Data.js'); ?>"></script>
-<?= $usegraphviz ? "" : "<script src=\"" . $module->assetUrl('javascript/jspdf.umd.min.js') . "\"></script>"; ?>
+<script src="<?= $module->assetUrl('javascript/jspdf.umd.min.js') ?>"></script>
 <script type="text/javascript">
     let graphvizAvailable = <?= $usegraphviz ? "true" : "false" ?>;
     let panzoomInst = null;


### PR DESCRIPTION
Fixed issue where jsPDF was not loaded in the browser when Graphviz installed on server, but some options require the PDF to be generated in the browser.

Removed conditional include and now jsPDF will always be loaded.

Resolves #552 