### PR TITLE
Change how Graphviz is called on server

### DIFF
--- a/app/OutputFile.php
+++ b/app/OutputFile.php
@@ -48,18 +48,44 @@ class OutputFile
      *
      * @return mixed
      */
-    private function getFileStream() {
+    private function getFileStream()
+    {
         $filename = $this->tempDir . "/" . $this->baseName;
         if (!empty($this->settings['graphviz_config']['output'][$this->fileType]['exec'])) {
-            $shell_cmd = str_replace($this->settings['filename'],  $this->tempDir . "/" .$this->settings['filename'], $this->settings['graphviz_config']['output'][$this->fileType]['exec']);
-            exec($shell_cmd." 2>&1", $stdout_output, $return_var);
-            if ($return_var !== 0)
-            {
-                die("Error (return code $return_var) executing command \"$shell_cmd\" in \"".getcwd()."\".<br>Graphviz error:<br><pre>".(join("\n", $stdout_output))."</pre>");
+            $shell_cmd = str_replace($this->settings['filename'], $this->tempDir . "/" . $this->settings['filename'], $this->settings['graphviz_config']['output'][$this->fileType]['exec']);
+            $descriptor_spec = array(
+                0 => array("pipe", "r"),
+                1 => array("pipe", "w"),
+                2 => array("pipe", "w")
+            );
+            $env = $_ENV;
+            unset($env['SERVER_NAME']);
+            if (!function_exists('proc_open')) {
+                exec($shell_cmd . " 2>&1", $stdout_output, $return_var);
+                if ($return_var !== 0) {
+                    die("Error (return code $return_var) executing command \"$shell_cmd\" in \"" . getcwd() . "\".<br>Graphviz error:<br><pre>" . (join("\n", $stdout_output)) . "</pre>");
+                }
+            } else {
+                $process = proc_open($shell_cmd, $descriptor_spec, $pipes, null, $env);
+                if (is_resource($process)) {
+                    fclose($pipes[0]);
+
+                    $stdout_output = stream_get_contents($pipes[1]);
+                    fclose($pipes[1]);
+
+                    $stderr_output = stream_get_contents($pipes[2]);
+                    fclose($pipes[2]);
+
+                    $return_code = proc_close($process);
+
+                    if ($return_code !== 0) {
+                        die("Error (return code $return_code) executing command \"$shell_cmd\" in \"" . getcwd() . "\".<br>Graphviz error:<br><pre>" . htmlspecialchars($stderr_output ?: $stdout_output) . "</pre>");
+                    }
+                } else {
+                    die("Failed to start process for command: $shell_cmd");
+                }
             }
         }
-
         return GVExport::getClass(StreamFactoryInterface::class)->createStreamFromFile($filename);
     }
-
 }


### PR DESCRIPTION
Updated exec to proc_open if available in order to resolve issue with SERVER_NAME being set and causing Graphviz to refuse to load images from files.

Retained exec fallback if needed.

Resolves #558 