### PR TITLE
Various reported fixes

### DIFF
--- a/app/Dot.php
+++ b/app/Dot.php
@@ -870,6 +870,8 @@ class Dot {
 							$out .= "</TR>";
 						}
 						$out .= "</TABLE>>";
+					} elseif (!empty($marriageplace_array[$i])) {
+						$out .= "<BR />";
 					}
 				}
 			}

--- a/app/Dot.php
+++ b/app/Dot.php
@@ -844,9 +844,6 @@ class Dot {
 						}
 					}
 					if ($hasDivorces) {
-						if ($hasMarriages) {
-							$out .= "<BR /><BR />";
-						}
 						$out .= "<FONT COLOR=\"". $this->settings["font_colour_details"] ."\" POINT-SIZE=\"" . ($this->settings["font_size"]) ."\">" . (empty($prefix_array[$i])?"":$prefix_array[$i]) . " " . (empty($divorceEmpty_array[$i])?"":$divorceEmpty_array[$i]) . " " . (empty($divorcedate_array[$i])?"":$divorcedate_array[$i]) . "<BR />" . (empty($divorceplace_array[$i])?"":"(".$divorceplace_array[$i].")") . "</FONT>";
 
 						if ($this->isPhotoRequired()) {
@@ -859,17 +856,17 @@ class Dot {
 					}
 
 					if ($i == $printCount) {
+						
+						if (!empty($family)) {
+							if (!empty($divorceplace_array[$i]) || (!empty($marriageplace_array[$i]) && empty($divorceplace_array[$i]))) {
+								$out .= "<BR />";
+							}
+						
+							$out .= "<FONT COLOR=\"". $this->settings["font_colour_details"] ."\" POINT-SIZE=\"" . ($this->settings["font_size"]) ."\">" . $family . "</FONT>";
+						}
 						# Last Fact
 						$out .= "</TD>";
-
 						$out .= "</TR>";
-						if (!empty($family)) {
-							$out .= "<TR>";
-							$out .= "<TD>";
-							$out .= "<FONT COLOR=\"". $this->settings["font_colour_details"] ."\" POINT-SIZE=\"" . ($this->settings["font_size"]) ."\">" . $family . "</FONT>";
-							$out .= "</TD>";
-							$out .= "</TR>";
-						}
 						$out .= "</TABLE>>";
 					} elseif (!empty($marriageplace_array[$i])) {
 						$out .= "<BR />";

--- a/app/Dot.php
+++ b/app/Dot.php
@@ -579,72 +579,73 @@ class Dot {
 			$fill_colour = $this->getFamilyColour();
 			$link = $f->url();
 
-			if ((count($marriages) == 0) && (count($divorces) == 0)) {
+			if ((count($marriages) == 0 && count($divorces) == 0) || !$this->settings["show_marriages"]) {
 				# No marriage or divorce events
 				#Increment the printCount in order to print a family without marriage
 				$printCount += 1;
 			}
 
-			# At least one marriage event
-			foreach ($marriages as $marriageFact) {
-				$printCount += 1;
+			if ($this->settings["show_marriages"]) {
+				# At least one marriage event
+				foreach ($marriages as $marriageFact) {
+					$printCount += 1;
 
-				// Set marriage prefix only if marriage exists
-				$married = ! empty($marriageFact);
-				if ($married) {
-					$prefix_array[$printCount] = $this->settings["marriage_prefix"] . ' ';
-				}
-	
-				if ($this->settings["show_marriage_type"]) {
-					$marriageType_array[$printCount] = '';
-					if (($marriageFact instanceof Fact)) {
-						$marriageAttributeType = $marriageFact->attribute('TYPE');
-						if ($marriageAttributeType !== '') {
-							$element = Registry::elementFactory()->make('FAM:MARR:TYPE');
-							$marriageType_array[$printCount] = $element->value($marriageAttributeType, $this->tree);
-						} else {
-							if ($this->settings["show_marriage_type"] && $this->settings["show_marriage_type_not_specified"]) {
-								$marriageType_array[$printCount] = I18N::translate('Unknown type of marriage') ;
+					// Set marriage prefix only if marriage exists
+					$married = ! empty($marriageFact);
+					if ($married) {
+						$prefix_array[$printCount] = $this->settings["marriage_prefix"] . ' ';
+					}
+		
+					if ($this->settings["show_marriage_type"]) {
+						$marriageType_array[$printCount] = '';
+						if (($marriageFact instanceof Fact)) {
+							$marriageAttributeType = $marriageFact->attribute('TYPE');
+							if ($marriageAttributeType !== '') {
+								$element = Registry::elementFactory()->make('FAM:MARR:TYPE');
+								$marriageType_array[$printCount] = $element->value($marriageAttributeType, $this->tree);
+							} else {
+								if ($this->settings["show_marriage_type"] && $this->settings["show_marriage_type_not_specified"]) {
+									$marriageType_array[$printCount] = I18N::translate('Unknown type of marriage') ;
+								}
 							}
 						}
 					}
-				}
-	
-				// Show marriage year
-				if ($this->settings["show_marriage_date"]) {
-					$marriagedate_array[$printCount] = $this->formatDate($marriageFact->date(), $this->settings["marr_date_year_only"],  $this->settings["use_abbr_month"]);
-				} else {
-					$marriagedate_array[$printCount] = "";
-				}
-	
-				// Show marriage place
-				if ($this->settings["show_marriage_place"] && !empty($marriageFact) && !empty($marriageFact->place())) {
-					$marriageplace_array[$printCount] = $this->getAbbreviatedPlace($marriageFact->place()->gedcomName(), $this->settings);
-				} else {
-					$marriageplace_array[$printCount] = "";
-				}
-
-				if (empty($marriageType_array[$printCount]) && empty($marriagedate_array[$printCount]) && empty($marriageplace_array[$printCount])) {
-					$marriageEmpty_array[$printCount] = I18N::translate('Married');
-				} else {
-					$marriageEmpty_array[$printCount] = "";
-				}
 		
-				if ($this->settings["show_marriage_first_image"] && $this->isPhotoRequired()) {
-					[$pic_marriage_first_array[$printCount], 
-					 $pic_marriage_first_title_array[$printCount], 
-					 $pic_marriage_first_link_array[$printCount]] = $this->addFirstPhotoFromSpecificFactToFam($marriageFact);
-				}
-	
-				// Get the husband's and wife's id from PGV
-				$husb_id = $this->families[$fid]["husb_id"] ?? "";
-				$wife_id = $this->families[$fid]["wife_id"] ?? "";
+					// Show marriage year
+					if ($this->settings["show_marriage_date"]) {
+						$marriagedate_array[$printCount] = $this->formatDate($marriageFact->date(), $this->settings["marr_date_year_only"],  $this->settings["use_abbr_month"]);
+					} else {
+						$marriagedate_array[$printCount] = "";
+					}
+		
+					// Show marriage place
+					if ($this->settings["show_marriage_place"] && !empty($marriageFact) && !empty($marriageFact->place())) {
+						$marriageplace_array[$printCount] = $this->getAbbreviatedPlace($marriageFact->place()->gedcomName(), $this->settings);
+					} else {
+						$marriageplace_array[$printCount] = "";
+					}
 
-				if ($this->settings["show_only_first_marriage"]) {
-					break;
+					if (empty($marriageType_array[$printCount]) && empty($marriagedate_array[$printCount]) && empty($marriageplace_array[$printCount])) {
+						$marriageEmpty_array[$printCount] = I18N::translate('Married');
+					} else {
+						$marriageEmpty_array[$printCount] = "";
+					}
+			
+					if ($this->settings["show_marriage_first_image"] && $this->isPhotoRequired()) {
+						[$pic_marriage_first_array[$printCount], 
+						$pic_marriage_first_title_array[$printCount], 
+						$pic_marriage_first_link_array[$printCount]] = $this->addFirstPhotoFromSpecificFactToFam($marriageFact);
+					}
+		
+					// Get the husband's and wife's id from PGV
+					$husb_id = $this->families[$fid]["husb_id"] ?? "";
+					$wife_id = $this->families[$fid]["wife_id"] ?? "";
+
+					if ($this->settings["show_only_first_marriage"]) {
+						break;
+					}
 				}
 			}
-
                         #---
                         #Divorce
 

--- a/app/Dot.php
+++ b/app/Dot.php
@@ -1934,7 +1934,7 @@ class Dot {
         $result = $values[$pedigree] ?? $values[PedigreeLinkageType::VALUE_BIRTH];
 
         if (!empty($result)) {
-            $result = 'label="'.$result.'", ';
+            $result = 'fontsize=' . $this->settings['font_size'] .', label="'.$result.'", ';
         }
         return $result;
     }

--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -182,6 +182,7 @@ class FormSubmission
             $settings['marr_date_year_only'] = ($vars['marr_date_year_only'] == 'true');
         }
 
+        $settings['show_marriages'] = isset($vars['show_marriages']);
         $settings['show_marriage_place'] = isset($vars['show_marriage_place']);
         $settings['use_alt_events'] = isset($vars['use_alt_events']);
         $settings['show_marriage_first_image'] = isset($vars['show_marriage_first_image']);

--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -491,7 +491,7 @@ class FormSubmission
      */
     private function isPrefixStringValid($name): bool
     {
-        return preg_match('/^[A-Za-z0-9_ .*+()^∞%$#@!†-↑↓×]*$/',$name);
+        return preg_match('/^[A-Za-z0-9_ .*+()^∞%$#@!†-↑↓×⚮]*$/',$name);
     }
 
     /**

--- a/app/Person.php
+++ b/app/Person.php
@@ -466,11 +466,13 @@ class Person
         $name = str_replace("_U_", "<u>", $name);
         $name = str_replace("_/U_", "</u> ", $name);
 
-        // If PID already in name (from another module), remove it, so we don't add twice
-        $name = str_replace(" (" . $pid . ")", "", $name);
-        if ($this->dot->settings["show_xref_individuals"] && !isset($vars["first_run_xref_check"])) {
-            // Show INDI id
-            $name = $name . " (" . $pid . ")";
+        if (!empty($pid)) {
+            // If PID already in name (from another module), remove it, so we don't add twice
+            $name = str_replace(" (" . $pid . ")", "", $name);
+            if ($this->dot->settings["show_xref_individuals"] && !isset($vars["first_run_xref_check"])) {
+                // Show INDI id
+                $name = $name . " (" . $pid . ")";
+            }
         }
         return $name;
     }

--- a/app/Person.php
+++ b/app/Person.php
@@ -336,7 +336,7 @@ class Person
             if ($rounded) {
                 $out .= "<TR><TD WIDTH=\"7\"></TD><TD COLSPAN=\"6\" CELLPADDING=\"2\" BGCOLOR=\"$stripe_colour\" PORT=\"nam\" $size></TD><TD WIDTH=\"7\"></TD></TR>";
             } else {
-                $out .= "<TR><TD COLSPAN=\"6\" CELLPADDING=\"2\" BGCOLOR=\"$stripe_colour\" PORT=\"nam\" $size></TD></TR>";
+                $out .= "<TR><TD COLSPAN=\"9\" CELLPADDING=\"2\" BGCOLOR=\"$stripe_colour\" PORT=\"nam\" $size></TD></TR>";
             }
         }
         // Second row (photo, name, birth, death & burial data)

--- a/config.php
+++ b/config.php
@@ -144,7 +144,7 @@ return array(
 	'death_prefix' => '†', // Text shown on chart before the death date - alternatively could use '↓'
     'burial_prefix' => '_', // Text shown on chart before the burial date
     'marriage_prefix' => '∞', // Text shown on chart before the marriage date
-    'divorce_prefix' => '×', // Text shown on chart before the divorce date
+    'divorce_prefix' => '⚮', // Text shown on chart before the divorce date
 	'limit_levels_visitor' => '5', // How many ancestor or descendant levels a user with this privilege can select up to
 	'limit_levels_member' => '10', // How many ancestor or descendant levels a user with this privilege can select up to
 	'limit_levels_editor' => '15', // How many ancestor or descendant levels a user with this privilege can select up to

--- a/config.php
+++ b/config.php
@@ -36,6 +36,7 @@ return array(
 	'burial_date_year_only' => false, // Whether to show just the year or the full GEDCOM date pf burial
 	'show_burial_place' => false, // Whether to show burial date for individuals
 	'show_burial_first_image' => false, // Whether to show burial first image of individuals
+	'show_marriages' => true, // Whether to show marriage details on family record
 	'show_only_first_marriage' => true, // Whether to show only the first marriage of the family record
 	'show_marriage_date' => true, // Whether to show marriage date on the family record
 	'show_marriage_first_image' => false, // Whether to show marriage first image of individuals

--- a/resources/javascript/MainPage/Form.js
+++ b/resources/javascript/MainPage/Form.js
@@ -789,6 +789,7 @@ const Form = {
             Form.showHideMatchCheckbox('highlight_custom_indis', 'highlight_custom_option');
             Form.showHideMatchCheckbox('show_marriage_type', 'marriage_type_subgroup');
             Form.showHideMatchCheckbox('show_divorces', 'divorces_subgroup');
+            Form.showHideMatchCheckbox('show_marriages', 'marriages_subgroup');
             setSavedDiagramsPanel();
             Form.showHide(document.getElementById('arrow_group'),document.getElementById('colour_arrow_related').checked)
             toggleUpdateButton();

--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -328,6 +328,11 @@ async function pageLoaded(Url) {
         Form.showHideMatchCheckbox('show_divorces', 'divorces_subgroup');
     });
 
+    let marriagesEl = form.querySelector("#show_marriages");
+    marriagesEl.addEventListener('change', function(e) {
+        Form.showHideMatchCheckbox('show_marriages', 'marriages_subgroup');
+    });
+
     window.addEventListener("scroll", (event) => {
         // Hide diagram context menu on scroll
         UI.contextMenu.clearContextMenu();

--- a/resources/views/MainPage/Appearance/TileContents.phtml
+++ b/resources/views/MainPage/Appearance/TileContents.phtml
@@ -137,33 +137,40 @@ use Fisharebest\Webtrees\I18N;
                 <label class="check-list width-90pc" for='show_xref_families'><?= I18N::translate('Show family XREF'); ?></label>
             </div>
             <div>
-                <input type="checkbox" name="vars[show_only_first_marriage]" id="show_only_first_marriage" value="show_only_first_marriage" <?= $vars["show_only_first_marriage"] ? 'checked' : '' ?>>
-                <label class="check-list width-90pc" for='show_only_first_marriage'><?= I18N::translate('Show only first marriage'); ?></label>
-            </div>
-            <div>
-                <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_marriage_date', 'marriage_date_subgroup');" name="vars[show_marriage_date]" id="show_marriage_date" value="show_marriage_date" <?= $vars["show_marriage_date"] ? 'checked' : '' ?>>
-                <label class="check-list width-90pc" for='show_marriage_date'><?= I18N::translate('Show marriage date'); ?></label>
-                <div id="marriage_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriage_date"] ? 'style="display:none;"' : '' ?>>
-                    <div class="col-auto mx-3">
-                        <input type="radio" name="vars[marr_date_year_only]" id="md_type_y" value="true" <?= $vars["marr_date_year_only"] ? 'checked' : '' ?>>
-                        <label for="md_type_y"><?= I18N::translate('Year') ?></label>
+                <input type="checkbox" name="vars[show_marriages]" id="show_marriages" value="show_marriages" <?= $vars["show_marriages"] ? 'checked' : '' ?>>
+                <label class="check-list width-90pc" for='show_marriages'><?= I18N::translate('Show marriages'); ?></label>
+                <div id="marriages_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriages"] ? 'style="display:none;"' : '' ?>>
+
+                    <div>
+                        <input type="checkbox" name="vars[show_only_first_marriage]" id="show_only_first_marriage" value="show_only_first_marriage" <?= $vars["show_only_first_marriage"] ? 'checked' : '' ?>>
+                        <label class="check-list width-90pc" for='show_only_first_marriage'><?= I18N::translate('Show only first marriage'); ?></label>
                     </div>
-                    <div class="col-auto mx-3">
-                        <input type="radio" name="vars[marr_date_year_only]" id="md_type_gedcom" value="false" <?= !$vars["marr_date_year_only"] ? 'checked' : '' ?>>
-                        <label for="md_type_gedcom"><?= I18N::translate('Full date') ?></label>
+                    <div>
+                        <input type="checkbox" onclick="Form.showHideMatchCheckbox('show_marriage_date', 'marriage_date_subgroup');" name="vars[show_marriage_date]" id="show_marriage_date" value="show_marriage_date" <?= $vars["show_marriage_date"] ? 'checked' : '' ?>>
+                        <label class="check-list width-90pc" for='show_marriage_date'><?= I18N::translate('Show marriage date'); ?></label>
+                        <div id="marriage_date_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriage_date"] ? 'style="display:none;"' : '' ?>>
+                            <div class="col-auto mx-3">
+                                <input type="radio" name="vars[marr_date_year_only]" id="md_type_y" value="true" <?= $vars["marr_date_year_only"] ? 'checked' : '' ?>>
+                                <label for="md_type_y"><?= I18N::translate('Year') ?></label>
+                            </div>
+                            <div class="col-auto mx-3">
+                                <input type="radio" name="vars[marr_date_year_only]" id="md_type_gedcom" value="false" <?= !$vars["marr_date_year_only"] ? 'checked' : '' ?>>
+                                <label for="md_type_gedcom"><?= I18N::translate('Full date') ?></label>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-            <div>
-                <input type="checkbox" name="vars[show_marriage_place]" id="show_marriage_place" value="show_marriage_place" <?= $vars["show_marriage_place"] ? 'checked' : '' ?>>
-                <label class="check-list width-90pc" for='show_marriage_place'><?= I18N::translate('Show marriage place'); ?></label>
-            </div>
-            <div>
-                <input type="checkbox" name="vars[show_marriage_type]" id="show_marriage_type" value="show_marriage_type" <?= $vars["show_marriage_type"] ? 'checked' : '' ?>>
-                <label class="check-list width-90pc" for='show_marriage_type'><?= I18N::translate('Show marriage type'); ?></label>
-                <div id="marriage_type_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriage_type"] ? 'style="display:none;"' : '' ?>>
-                    <input type="checkbox" name="vars[show_marriage_type_not_specified]" id="show_marriage_type_not_specified" value="show_marriage_type_not_specified" <?= $vars["show_marriage_type_not_specified"] ? 'checked' : '' ?>>
-                    <label class="check-list width-90pc" for='show_marriage_type_not_specified' class="width-80pc check-list"><?= I18N::translate('Show when type is not specified'); ?></label>
+                    <div>
+                        <input type="checkbox" name="vars[show_marriage_place]" id="show_marriage_place" value="show_marriage_place" <?= $vars["show_marriage_place"] ? 'checked' : '' ?>>
+                        <label class="check-list width-90pc" for='show_marriage_place'><?= I18N::translate('Show marriage place'); ?></label>
+                    </div>
+                    <div>
+                        <input type="checkbox" name="vars[show_marriage_type]" id="show_marriage_type" value="show_marriage_type" <?= $vars["show_marriage_type"] ? 'checked' : '' ?>>
+                        <label class="check-list width-90pc" for='show_marriage_type'><?= I18N::translate('Show marriage type'); ?></label>
+                        <div id="marriage_type_subgroup" class="setting_subgroup col-auto options-panel-background" <?= !$vars["show_marriage_type"] ? 'style="display:none;"' : '' ?>>
+                            <input type="checkbox" name="vars[show_marriage_type_not_specified]" id="show_marriage_type_not_specified" value="show_marriage_type_not_specified" <?= $vars["show_marriage_type_not_specified"] ? 'checked' : '' ?>>
+                            <label class="check-list width-90pc" for='show_marriage_type_not_specified' class="width-80pc check-list"><?= I18N::translate('Show when type is not specified'); ?></label>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div>

--- a/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
+++ b/resources/views/MainPage/Help/Detailed information/Appearance/Tile contents.phtml
@@ -133,6 +133,11 @@ $help = new Help();
     <?= I18N::translate('Whether to include the XREF of families in the output.'); ?>
 </p>
 
+<h5><?= I18N::translate('Show marriages'); ?></h5>
+<p>
+    <?= I18N::translate('If selected, marriages will be listed on the family record.'); ?>
+</p>
+
 <h5><?= I18N::translate('Show only first marriage'); ?></h5>
 <p>
     <?= I18N::translate('If a couple have been married more than once (a family record in webtrees has multiple marriage events), if this option is selected then only the first is shown (this is the default). If you unselect this option, all marriage events will be shown in the same family record in the diagram.'); ?>


### PR DESCRIPTION
This pull request fixes the following issues raised in #571:
- Divorce details now on new line when marriage place enabled
- Changed divorce prefix to the divorce symbol ⚮
- Font size for details now used for arrow labels
- Added option to show or hide marriages, and marriage options are grouped under this.

Resolves issue where coloured stripe doesn't fill whole width if extra images are shown, from issue #572

Resolves issue with parenthesis in secondary name, from issue #573