### PR TITLE
Fullscreen tweaks

### DIFF
--- a/resources/javascript/gvexport.js
+++ b/resources/javascript/gvexport.js
@@ -368,7 +368,8 @@ function showModal(content) {
         '<span class="close" onclick="document.getElementById(' + "'modal'" + ').remove()">&times;</span>\n' +
         content + "\n" +
         "</div>"
-    document.body.appendChild(modal);
+    const renderContainer = document.getElementById("render-container")
+    renderContainer.appendChild(modal);
     // When the user clicks anywhere outside the modal, close it
     window.onclick = function(event) {
         if (event.target === modal) {


### PR DESCRIPTION
Tweak to show the menu when exiting full screen (to add to previous change to hide menu when entering full screen)

Moved modal element inside render container to allow modal windows to work while in full screen.

Resolves #587 