### PR TITLE
Fix settings and browser PDF download

### DIFF
--- a/resources/javascript/MainPage/Data.js
+++ b/resources/javascript/MainPage/Data.js
@@ -250,6 +250,7 @@ const Data = {
             const heightInches = height / dpi;
             const doc = new window.jspdf.jsPDF({orientation: orientation, format: [widthInches, heightInches], unit: 'in', compress: true});
             doc.addImage(imgData, "PNG", 0, 0, widthInches, heightInches);
+            doc.save(download_file_name + ".pdf");
         },
 
         /**
@@ -263,6 +264,7 @@ const Data = {
             downloadLinkElement.href = URL;
             downloadLinkElement.download = filename;
             document.body.appendChild(downloadLinkElement);
+            downloadLinkElement.click();
             document.body.removeChild(downloadLinkElement);
         },
     },


### PR DESCRIPTION
Fixes two issues:
- Downloading a settings file now works
- Downloading a PDF when graphviz is not installed on server or option chosen that can't be done on server

Related #612 