### PR TITLE
Include clippings cart in saved settings

### DIFF
--- a/app/ApiHandler.php
+++ b/app/ApiHandler.php
@@ -457,19 +457,14 @@ class ApiHandler
             if (!FormSubmission::isXrefListValid($xref)) {
                 continue;
             }
-
-            if ($this->json['record_type'] === 'families') {
-                $record = Registry::familyFactory()->make($xref, $this->tree);
-                if ($record) {
-                    $cartAdder->addFamilyToCart($record);
-                }
+            $record = Registry::familyFactory()->make($xref, $this->tree);
+            if ($record) {
+                $cartAdder->addFamilyToCart($record);
             }
 
-            if ($this->json['record_type'] === 'individuals') {
-                $record = Registry::individualFactory()->make($xref, $this->tree);
-                if ($record) {
-                    $cartAdder->addIndividualToCart($record);
-                }
+            $record = Registry::individualFactory()->make($xref, $this->tree);
+            if ($record) {
+                $cartAdder->addIndividualToCart($record);
             }
         }
         $this->response_data['success'] = true;

--- a/app/ApiHandler.php
+++ b/app/ApiHandler.php
@@ -149,7 +149,7 @@ class ApiHandler
     public function saveSettings(): void
     {
         $vars = Validator::parsedBody($this->request)->array('vars');
-        $formSubmission = new FormSubmission();
+        $formSubmission = new FormSubmission($this->request->getAttribute('tree'));
         $vars = $formSubmission->load($vars, $this->module);
         if (isset($this->json['settings_id']) && ctype_alnum((string) $this->json['settings_id']) && !in_array($this->json['settings_id'], [Settings::ID_ALL_SETTINGS, Settings::ID_MAIN_SETTINGS])) {
             if ($this->doesSettingsIdBelongsToUser()) {
@@ -200,7 +200,7 @@ class ApiHandler
             // Treat logged-out users special if requesting ID_MAIN_SETTINGS
             if ($this->json['settings_id'] == Settings::ID_MAIN_SETTINGS && Auth::user()->id() == Settings::GUEST_USER_ID) {
                 $vars = Validator::parsedBody($this->request)->array('vars');
-                $form = new FormSubmission();
+                $form = new FormSubmission($this->request->getAttribute('tree'));
                 $settings_response = $form->load($vars, $this->module);
                 try {
                     $this->response_data['settings'] = $settings->getJsonFromSettings($settings_response, Settings::CONTEXT_MAIN_SETTINGS);

--- a/app/ClippingsCart.php
+++ b/app/ClippingsCart.php
@@ -62,7 +62,7 @@ class ClippingsCart {
 	 *
 	 * @return array of XREFs
 	 */
-	private static function getXrefsInCart(Tree $tree): array
+	public static function getXrefsInCart(Tree $tree): array
 	{
 		$cart = Session::get('cart', []);
 		$xrefs = array_keys($cart[$tree->name()] ?? []);

--- a/app/FormSubmission.php
+++ b/app/FormSubmission.php
@@ -3,12 +3,19 @@
 namespace vendor\WebtreesModules\gvexport;
 
 use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Tree;
 
 /**
  * Form handling functionality
  */
 class FormSubmission
 {
+    private ?Tree $tree;
+
+    public function __construct(?Tree $tree)
+    {
+        $this->tree = $tree;
+    }
     /**
      * Takes list of values from form submission and returns structures and
      * validated settings list
@@ -216,8 +223,14 @@ class FormSubmission
 
         $settings['use_abbr_month'] = isset($vars['use_abbr_month']);
 
+        $settings['saved_cart_xrefs'] = '';
         if (isset($vars['use_cart'])) {
             $settings['use_cart'] = ($vars['use_cart'] !== "ignorecart");
+
+            // Can be called from webtrees Control Panel page, where there is no Tree
+            if ($settings['use_cart'] && $this->tree != null) {
+                $settings['saved_cart_xrefs'] = ClippingsCart::getXrefsInCart($this->tree);
+            }
         } else {
             $settings['use_cart'] = false;
         }

--- a/module.php
+++ b/module.php
@@ -297,7 +297,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
     public function postAdminAction(ServerRequestInterface $request): ResponseInterface
     {
         $params = (array) $request->getParsedBody();
-        $formSubmission = new FormSubmission();
+        $formSubmission = new FormSubmission($request->getAttribute('tree'));
         $vars_data = Validator::parsedBody($request)->array('vars');
         $vars = $formSubmission->load($vars_data, $this);
         if ($params['save'] === '1') {
@@ -374,7 +374,7 @@ class GVExport extends AbstractModule implements ModuleCustomInterface, ModuleCh
 
     function createDot($tree, $vars_data, $settings) {
         $dot = new Dot($tree, $this);
-        $formSubmission = new FormSubmission();
+        $formSubmission = new FormSubmission($tree);
         $vars = $formSubmission->load($vars_data, $this);
         if (isset($temp_dir)) {
             $vars['temp_dir'] = $temp_dir;

--- a/playwright/tests/common/utils.ts
+++ b/playwright/tests/common/utils.ts
@@ -88,11 +88,11 @@ export async function getLogin(role = 'user', id: number) {
  * @param page 
  */
 export async function clearSavedSettingsList(page: Page) {
-    const items = page.locator('.settings_list_item');
+    const items = await page.locator('.settings_list_item');
     const count = await items.count();
     
     for (let i = 0; i < count; i++) {
-        const item = items.nth(0);
+        const item = await items.nth(0);
         await item.getByText('…').click();
         await item
             .locator('.settings_ellipsis_menu')

--- a/resources/javascript/MainPage/Form.js
+++ b/resources/javascript/MainPage/Form.js
@@ -835,6 +835,11 @@ const Form = {
                 let el = document.getElementById(key);
                 if (el == null) {
                     switch (key) {
+                        case 'saved_cart_xrefs':
+                            if (settings[key] !== '') {
+                                UI.tile.addXrefsToClippingsCartSavedSetting(settings[key]);
+                            }
+                            break;
                         case 'diagram_type':
                             if (settings[key] === 'simple') {
                                 setTimeout(() => {

--- a/resources/javascript/MainPage/UI.js
+++ b/resources/javascript/MainPage/UI.js
@@ -261,7 +261,7 @@ const UI = {
                                 UI.tile.goToAddParent(url, xref);
                                 break;
                             case '100': // Add to clippings cart
-                                UI.tile.addIndividualsToClippingsCart([xref]);
+                                UI.tile.addXrefsToClippingsCart([xref]);
                                 break;
                             case '60': // Do nothing option
                             default: // Unknown, so do nothing
@@ -286,7 +286,7 @@ const UI = {
                                 UI.tile.changeFamilyMembers(url, xref);
                                 break;
                             case '60': // Add to clippings cart
-                                UI.tile.addFamiliesToClippingsCart([xref]);
+                                UI.tile.addXrefsToClippingsCart([xref]);
                                 break;
                             case '30': // Show menu
                                 UI.tile.showFamilyContextMenu(e, url, xref);
@@ -430,7 +430,7 @@ const UI = {
          */
         addIndividualToCartContextMenu(e) {
             let xref = e.currentTarget.parentElement.getAttribute('data-xref');
-            UI.tile.addIndividualsToClippingsCart([xref]);
+            UI.tile.addXrefsToClippingsCart([xref]);
         },
 
         /**
@@ -460,7 +460,7 @@ const UI = {
          */
         addFamilyToCartContextMenu(e) {
             let xref = e.currentTarget.parentElement.getAttribute('data-xref');
-            UI.tile.addFamiliesToClippingsCart([xref]);
+            UI.tile.addXrefsToClippingsCart([xref]);
         },
 
         /**
@@ -517,10 +517,10 @@ const UI = {
         },
 
         /**
-         * Add the family to the clippings cart
+         * Add the XREF records to the clippings cart
          */
-        addFamiliesToClippingsCart(xrefs) {
-            this.addXrefsToClippingsCart(xrefs, 'families').then((response) => {
+        addXrefsToClippingsCart(xrefs) {
+            this.addXrefsToClippingsCartRequest(xrefs).then((response) => {
                 if (response) {
                     Form.updateClippingsCartCount();
                     UI.showToast(TRANSLATE[response]);
@@ -532,27 +532,11 @@ const UI = {
         },
 
         /**
-         * Add the individual to the clippings cart
+         * Send the server request to add the array of xrefs to the clippings cart
          */
-        addIndividualsToClippingsCart(xrefs) {
-            this.addXrefsToClippingsCart(xrefs, 'individuals').then((response) => {
-                if (response) {
-                    Form.updateClippingsCartCount();
-                    UI.showToast(TRANSLATE[response]);
-                    UI.contextMenu.clearContextMenu();
-                } else {
-                    UI.showToast(ERROR_CHAR + TRANSLATE['Unknown error']);
-                }
-            });
-        },
-
-        /**
-         * Add the array of xrefs to the clippings cart
-         */
-        addXrefsToClippingsCart(xrefs, type) {
+        addXrefsToClippingsCartRequest(xrefs) {
                 let request = {
                 "type": REQUEST_TYPE_ADD_CLIPPINGS_CART,
-                "record_type": type,
                 "xrefs": xrefs,
             };
             return Data.callAPI(request);

--- a/resources/javascript/MainPage/UI.js
+++ b/resources/javascript/MainPage/UI.js
@@ -519,6 +519,30 @@ const UI = {
         /**
          * Add the XREF records to the clippings cart
          */
+        addXrefsToClippingsCartSavedSetting(xrefs, userPrompted = false) {
+            if (userPrompted) {
+                this.addXrefsToClippingsCart(xrefs);
+            } else {
+                let message = TRANSLATE["This saved setting contains clippings cart items, add them to the clippings cart?"];
+                let buttons = '<div class="modal-button-container"><button id="modal-cancel" class="btn btn-secondary modal-button" >' + TRANSLATE['Cancel'] + '</button><button id="modal-yes" class="btn btn-primary modal-button" >' + TRANSLATE['Yes'] + '</button></div>';
+                showModal('<div class="modal-container">' + message + '<br>' + buttons + '</div>');
+                
+                document.getElementById('modal-cancel').onclick = () => {
+                    document.getElementById('modal').remove();
+                };
+
+                document.getElementById('modal-yes').onclick = () => {
+                    UI.tile.addXrefsToClippingsCartSavedSetting(xrefs, true);
+                    document.getElementById('modal').remove();
+                };
+
+                return false;
+            }
+        },
+
+        /**
+         * Add the XREF records to the clippings cart
+         */
         addXrefsToClippingsCart(xrefs) {
             this.addXrefsToClippingsCartRequest(xrefs).then((response) => {
                 if (response) {

--- a/resources/views/MainPage/Translations.phtml
+++ b/resources/views/MainPage/Translations.phtml
@@ -5,6 +5,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 <script type="text/javascript">
     const TRANSLATE = {
+        "Yes": "<?= I18N::translate('yes'); ?>",
         "Delete": "<?= I18N::translate('Delete'); ?>",
         "Download": "<?= I18N::translate('Download'); ?>",
         "Copy link": "<?= I18N::translate('Copy link'); ?>",
@@ -20,7 +21,7 @@ use Fisharebest\Webtrees\I18N;
         "Added to Tree favourites": "<?= I18N::translate('Added to Tree favourites'); ?>",
         "Source individual has replaced existing individual": "<?= I18N::translate('Source individual has replaced existing individual'); ?>",
         "One new source individual added to %s existing individuals": "<?= I18N::translate('One new source individual added to %s existing individuals', '%s'); ?>",
-        "Cancel": "<?= I18N::translate('Cancel'); ?>",
+        "Cancel": "<?= I18N::translate('cancel'); ?>",
         "Overwrite": "<?= I18N::translate('Overwrite'); ?>",
         "Individual not found": "<?= I18N::translate('Individual not found') ?>",
         "Diagram will be rendered in browser as server doesn't support photo shapes": "<?= I18N::translate("Diagram will be rendered in browser as server doesn't support photo shapes"); ?>",
@@ -47,6 +48,7 @@ use Fisharebest\Webtrees\I18N;
         "Change family members": "<?= I18N::translate('Change family members'); ?>",
         "Add to clippings cart": "<?= I18N::translate('Add to clippings cart'); ?>",
         "Added to clippings cart": "<?= I18N::translate('Added to clippings cart'); ?>",
+        "This saved setting contains clippings cart items, add them to the clippings cart?": "<?= I18N::translate('This saved setting contains clippings cart items, add them to the clippings cart?'); ?>",
         "Unknown error": "<?= I18N::translate('Unknown error'); ?>",
         "Add a partner": "<?= I18N::translate('Add a partner'); ?>",
         "Add a parent": "<?= I18N::translate('Add a parent'); ?>",


### PR DESCRIPTION
This PR introduces a change where if you save settings to your saved settings list while there are items in the clippings cart AND the clippings cart is being used (not ignored), the clippings cart XREFS are saved with the saved settings.

When loading, any XREFs for families or individuals will be ADDED to the clippings cart after confirming a pop up modal.

Items that are not families or individuals are ignored, however, the CURRENT linked objects will also be added to the clippings cart.

Also includes playwright tests.

Closes #331 