### PR TITLE
Fix odd error

### DIFF
--- a/app/Dot.php
+++ b/app/Dot.php
@@ -283,7 +283,7 @@ class Dot
 			// If individuals in clipping cart and option chosen to use them, then proceed
 
 			$cart = new ClippingsCart($this->tree);
-			$lists = new ClippingsCartListBuilder($cart)->getLists();
+			$lists = (new ClippingsCartListBuilder($cart))->getLists();
 			$enhancedLists = (new ClippingsCartListEnhancer($cart, $lists, $this->isPhotoRequired(), $this->settings['dpi'], ($this->settings["diagram_type"] == "combined")))->enhance();
 
 			$this->individuals = $enhancedLists['individuals'];


### PR DESCRIPTION
Attempts to fix a syntax error that is not consistent.

@schuco can you try this version, that you can download here: https://github.com/Neriderc/GVExport/archive/refs/heads/fix-error.zip

This is a very odd error.  I installed the `main` branch to my production server to test, and was able to reproduce the error discussed in #661. However, that production server was running Webtrees 2.2.4. When I updated it to 2.2.5, the error went away.

I tried downgrading my development server to 2.2.4, and the error showed there. But you've said you're running 2.2.5 so that can't be it!

For some reason PHP must be trying to resolve things out of order. I have added some brackets to force it to resolve in the right order, and this has fixed it for me even in webtrees 2.2.4.

Hopefully it fixes it for you too @schuco?