### PR TITLE
Fix download of files with photos from clippings cart

### DIFF
--- a/app/ClippingsCartListEnhancer.php
+++ b/app/ClippingsCartListEnhancer.php
@@ -178,7 +178,7 @@ class ClippingsCartListEnhancer
 			if (isset($mediaFile) && !$mediaFile->isExternal()) {
 				$media_title = strip_tags($individual->fullName());
 				// If we are rendering in the browser, provide the URL, otherwise provide the server side file location
-				if (isset($_REQUEST["render"])) {
+				if (isset($_REQUEST["browser"]) && $_REQUEST["browser"] === "false") {
 					$pic = Site::getPreference('INDEX_DIRECTORY') . $this->tree->getPreference('MEDIA_DIRECTORY') . $mediaFile->filename();
 				} else {
 					$pic = str_replace("&", "%26", $mediaFile->imageUrl($this->dpi, $this->dpi, "contain"));

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^17.2.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.58.2",
         "@types/node": "^24.10.1",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.57.1",
@@ -163,12 +163,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -821,6 +822,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1367,12 +1369,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1385,10 +1388,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,4 +1,4 @@
-  {
+{
   "name": "playwright",
   "version": "1.0.0",
   "description": "",
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^24.10.1",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.57.1",

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   /* Run tests in files in parallel */
   //fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -22,39 +22,40 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: 'http://localhost:8089',
+    baseURL: "http://localhost:8089",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
+  timeout: 60_000,
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'admin',
-      testDir: 'tests/admin',
+      name: "admin",
+      testDir: "tests/admin",
       use: {
-        ...devices['Desktop Chrome'],
+        ...devices["Desktop Chrome"],
       },
     },
 
     {
-      name: 'user',
-      testDir: 'tests/user',
-      use: { 
-        ...devices['Desktop Chrome'],
+      name: "user",
+      testDir: "tests/user",
+      use: {
+        ...devices["Desktop Chrome"],
       },
     },
 
     {
-      name: 'guest',
-      testDir: 'tests/guest',
+      name: "guest",
+      testDir: "tests/guest",
       use: {
-        ...devices['Desktop Chrome'],
+        ...devices["Desktop Chrome"],
         storageState: undefined,
       },
     },
@@ -62,14 +63,14 @@ export default defineConfig({
     // {
     //   name: 'user',
     //   testDir: 'tests/user',
-    //   use: { 
+    //   use: {
     //     ...devices['Desktop Firefox'],
     //   },
     // },
 
     // {
     //   name: 'webkit',
-    //   use: { 
+    //   use: {
     //     ...devices['Desktop Safari'],
     //   },
     // },

--- a/playwright/tests/common/sharedGeneralTests.ts
+++ b/playwright/tests/common/sharedGeneralTests.ts
@@ -3,7 +3,7 @@ import { getTileByXref, loadGVExport, addFamilyToClippingsCartViaMenu } from '..
 
 export function runSharedGeneralTests(role: 'guest' | 'user') {
     test.describe('Check all download types trigger download', () => {
-        runDownloadTests(['svg', 'pdf', 'png', 'jpg', 'gif', 'ps', 'dot']);
+        runDownloadTests(['svg', 'pdf', 'png', 'jpg', 'gif', 'ps', 'dot'], role);
     });
 
 
@@ -87,7 +87,7 @@ export function runSharedGeneralTests(role: 'guest' | 'user') {
     });
 }
 
-export function runDownloadTests(options: Array<string>) {
+export function runDownloadTests(options: Array<string>, role: string) {
     for (const value of options) {
         test(`Download triggers for ${value}`, async ({ page }) => {
             await loadGVExport(page);
@@ -105,5 +105,33 @@ export function runDownloadTests(options: Array<string>) {
 
             expect(pageErrors).toHaveLength(0);
         });
+    }
+
+    if (role === "user") {
+        for (const value of options) {
+            test(`Download triggers for ${value} with Clippings Cart enabled`, async ({ page }) => {
+                await loadGVExport(page, true);
+                await page.getByRole('button', { name: 'Add all diagram items to clippings cart' }).click();
+                await expect(page.locator('.toast-message').filter({ hasText: 'Added to clippings cart' })).toBeVisible();
+                await expect(await page.locator('#cart-section')).toBeVisible();
+                await page.locator('.menu-clippings').getByRole('button', { name: 'Clippings cart' }).click();
+                await expect(page.locator('.menu-clippings-cart .badge').first()).toHaveText('31')
+
+                await page.check('#usecart_yes');
+
+                await page.selectOption('#output_type', value);
+                await expect(page.locator('#rendering svg')).toBeVisible();
+
+                const pageErrors: Error[] = [];
+                page.on('pageerror', err => pageErrors.push(err));
+
+                const [download] = await Promise.all([
+                    page.waitForEvent('download'),
+                    page.getByRole('button', { name: /Download/i }).click(),
+                ]);
+
+                expect(pageErrors).toHaveLength(0);
+            });
+        }
     }
 }


### PR DESCRIPTION
As discussed in #662, there's a issue downloading a PDF document where the diagram uses the clippings cart and diagram contains photos, which only applies when Graphviz is installed on the server.

This PR will hopefully resolve the issue!

I have also added an automated test for this scenario to the Playwright suite, and tested that it fails before the change and passes with the change.